### PR TITLE
feat: update home copy and blog heading (EN + ES)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,12 +10,12 @@ export const SITE: Site = {
 
 export const HOME_EN: Metadata = {
   TITLE: "Home",
-  DESCRIPTION: "Rambling.",
+  DESCRIPTION: "Developer, tech lead, recovering designer. 20 years shipping things.",
 };
 
 export const HOME_ES: Metadata = {
   TITLE: "Inicio",
-  DESCRIPTION: "Divagando.",
+  DESCRIPTION: "Desarrollador, tech lead, diseñador en rehabilitación. 20 años construyendo cosas.",
 };
 
 export const BLOG_EN: Metadata = {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -21,11 +21,13 @@ export const HOME_ES: Metadata = {
 export const BLOG_EN: Metadata = {
   TITLE: "Blog",
   DESCRIPTION: "Posts on tech, design, and whatever else.",
+  TAGLINE: "Rambling.",
 };
 
 export const BLOG_ES: Metadata = {
   TITLE: "Blog",
   DESCRIPTION: "Posts sobre tecnología, diseño y lo que sea.",
+  TAGLINE: "Divagando.",
 };
 
 export const WORK_EN: Metadata = {
@@ -64,10 +66,16 @@ export const CREDITS_ES: Metadata = {
 
 export const AUTHOR = {
   NAME: "Javier Zapata",
+  H1_EN: "Hi, I’m Javi.",
+  H1_ES: "Hola, soy Javi.",
   BIO_EN:
     "I’m a developer, tech lead, and recovering designer that has been shipping things for more than 20 years. Still learning, though.",
   BIO_ES:
     "Soy desarrollador, tech lead y diseñador en rehabilitación que lleva más de 20 años lanzando cosas. Aun así, sigo aprendiendo.",
+  BRIDGE_EN:
+    "Here you’ll find what I’m working on, what I’ve built, and the occasional write-up about code, AI, and tooling.",
+  BRIDGE_ES:
+    "Aquí encontrarás en qué trabajo, qué he construido y algún que otro artículo sobre código, IA y herramientas.",
   AVATAR: "/avatar.jpg",
 };
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -16,7 +16,7 @@ const { title, description, image } = Astro.props;
 <!doctype html>
 <html lang={Astro.currentLocale ?? "es"}>
   <head>
-    <Head title={`${title} | ${SITE.NAME}`} description={description} image={image} />
+    <Head title={title === SITE.NAME ? title : `${title} | ${SITE.NAME}`} description={description} image={image} />
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -30,7 +30,7 @@ const icons = getIconMap(import.meta.glob("/src/assets/blog/*/icon.*", { eager: 
   <Container>
     <div class="space-y-10">
       <div class="animate font-semibold text-black dark:text-white">
-        Rambling.
+        {BLOG.TAGLINE}
       </div>
       <div class="space-y-4">
         {years.map(year => (

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -30,7 +30,7 @@ const icons = getIconMap(import.meta.glob("/src/assets/blog/*/icon.*", { eager: 
   <Container>
     <div class="space-y-10">
       <div class="animate font-semibold text-black dark:text-white">
-        Blog
+        Rambling.
       </div>
       <div class="space-y-4">
         {years.map(year => (

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -32,10 +32,13 @@ const projectIcons = getIconMap(import.meta.glob("/src/assets/projects/*/icon.*"
       <section>
         <article class="space-y-4">
           <h1 class="animate text-3xl font-semibold text-black dark:text-white">
-            {HOME.DESCRIPTION}
+            Hi, I'm Javi.
           </h1>
           <p class="animate">
             {AUTHOR.BIO_EN}
+          </p>
+          <p class="animate">
+            Here you'll find what I'm working on, what I've built, and the occasional write-up about code, AI, and tooling.
           </p>
         </article>
       </section>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -32,13 +32,13 @@ const projectIcons = getIconMap(import.meta.glob("/src/assets/projects/*/icon.*"
       <section>
         <article class="space-y-4">
           <h1 class="animate text-3xl font-semibold text-black dark:text-white">
-            Hi, I'm Javi.
+            {AUTHOR.H1_EN}
           </h1>
           <p class="animate">
             {AUTHOR.BIO_EN}
           </p>
           <p class="animate">
-            Here you'll find what I'm working on, what I've built, and the occasional write-up about code, AI, and tooling.
+            {AUTHOR.BRIDGE_EN}
           </p>
         </article>
       </section>

--- a/src/pages/es/blog/index.astro
+++ b/src/pages/es/blog/index.astro
@@ -30,7 +30,7 @@ const icons = getIconMap(import.meta.glob("/src/assets/blog/*/icon.*", { eager: 
   <Container>
     <div class="space-y-10">
       <div class="animate font-semibold text-black dark:text-white">
-        Divagando.
+        {BLOG.TAGLINE}
       </div>
       <div class="space-y-4">
         {years.map(year => (

--- a/src/pages/es/blog/index.astro
+++ b/src/pages/es/blog/index.astro
@@ -30,7 +30,7 @@ const icons = getIconMap(import.meta.glob("/src/assets/blog/*/icon.*", { eager: 
   <Container>
     <div class="space-y-10">
       <div class="animate font-semibold text-black dark:text-white">
-        Blog
+        Divagando.
       </div>
       <div class="space-y-4">
         {years.map(year => (

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -32,10 +32,13 @@ const projectIcons = getIconMap(import.meta.glob("/src/assets/projects/*/icon.*"
       <section>
         <article class="space-y-4">
           <h1 class="animate text-3xl font-semibold text-black dark:text-white">
-            {HOME.DESCRIPTION}
+            Hola, soy Javi.
           </h1>
           <p class="animate">
             {AUTHOR.BIO_ES}
+          </p>
+          <p class="animate">
+            Aquí encontrarás en qué trabajo, qué he construido y algún que otro artículo sobre código, IA y herramientas.
           </p>
         </article>
       </section>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -32,13 +32,13 @@ const projectIcons = getIconMap(import.meta.glob("/src/assets/projects/*/icon.*"
       <section>
         <article class="space-y-4">
           <h1 class="animate text-3xl font-semibold text-black dark:text-white">
-            Hola, soy Javi.
+            {AUTHOR.H1_ES}
           </h1>
           <p class="animate">
             {AUTHOR.BIO_ES}
           </p>
           <p class="animate">
-            Aquí encontrarás en qué trabajo, qué he construido y algún que otro artículo sobre código, IA y herramientas.
+            {AUTHOR.BRIDGE_ES}
           </p>
         </article>
       </section>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Site = {
 export type Metadata = {
   TITLE: string;
   DESCRIPTION: string;
+  TAGLINE?: string;
 };
 
 export type Socials = {


### PR DESCRIPTION
## Summary

- Replace `Rambling.` h1 on home with `Hi, I'm Javi.` / `Hola, soy Javi.`
- Update home meta-description (`<meta name="description">`, `og:description`, `twitter:description`) to profile-oriented copy in both languages
- Add bridge paragraph below the bio orienting visitors to blog/work/projects sections
- Move `Rambling.` / `Divagando.` to the blog section heading
- Fix duplicate `<title>` on the language-selection landing page (`Hic sunt dracones | Hic sunt dracones` → `Hic sunt dracones`)

## Test plan

- [ ] `astro build` passes with 0 errors
- [ ] `/en/` — h1 reads `Hi, I'm Javi.`, meta-description reflects new copy
- [ ] `/es/` — h1 reads `Hola, soy Javi.`, meta-description reflects new copy
- [ ] `/en/blog` — section heading reads `Rambling.`
- [ ] `/es/blog` — section heading reads `Divagando.`
- [ ] `/` — page title is `Hic sunt dracones` (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)