### PR TITLE
feat(cv): CV generation — ATS PDF & DOCX from content collections

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git log --format=%cs to find correct commit
 
       - uses: pnpm/action-setup@v4
 
@@ -21,7 +23,21 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm run build
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: playwright-chromium-
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build site
+        run: pnpm run build
+
+      - name: Generate CV documents
+        run: node scripts/generate-pdf.mjs && node scripts/generate-docx.mjs
 
       - name: Deploy to gh-pages
         env:
@@ -31,3 +47,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
           pnpm run deploy
+

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ resources/
 
 # CV full profile (contains phone — never commit)
 src/content/profile/full.json
+
+# Generated CV documents (built by generate:cv — never commit binaries)
+public/cv/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ pnpm-debug.log*
 # Deployment targets
 .netlify/
 resources/
+
+# CV full profile (contains phone — never commit)
+src/content/profile/full.json

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
+import { resolve } from "node:path";
 
 export default defineConfig({
   site: "https://javi.io",
@@ -16,6 +17,11 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        "@cv": resolve("./src/cv"),
+      },
+    },
   },
   i18n: {
     defaultLocale: "es",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,9 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "node:path";
+import { computeCvMeta } from "./scripts/cv-meta.mjs";
+
+const { hash: CV_HASH, updated: CV_UPDATED } = computeCvMeta();
 
 export default defineConfig({
   site: "https://javi.io",
@@ -17,6 +20,10 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss()],
+    define: {
+      "import.meta.env.PUBLIC_CV_HASH": JSON.stringify(CV_HASH),
+      "import.meta.env.PUBLIC_CV_UPDATED": JSON.stringify(CV_UPDATED),
+    },
     resolve: {
       alias: {
         "@cv": resolve("./src/cv"),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "astro": "astro",
     "deploy": "gh-pages --dotfiles -d dist",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "generate:pdf": "node scripts/generate-pdf.mjs",
+    "generate:docx": "node scripts/generate-docx.mjs",
+    "generate:cv": "pnpm run generate:pdf && pnpm run generate:docx"
   },
   "dependencies": {
     "@astrojs/markdown-satteri": "^0.2.1",
@@ -44,6 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "gh-pages": "^6.3.0",
     "globals": "^16.0.0",
+    "playwright": "^1.60.0",
     "typescript": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,13 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
+    "docx": "^9.7.1",
     "eslint": "^10.0.0",
     "eslint-plugin-astro": "^1.0.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "gh-pages": "^6.3.0",
     "globals": "^16.0.0",
+    "gray-matter": "^4.0.3",
     "playwright": "^1.60.0",
     "typescript": "^6.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.2.1
       '@astrojs/mdx':
         specifier: ^6.0.1
-        version: 6.0.1(@astrojs/markdown-satteri@0.2.1)(astro@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0))
+        version: 6.0.1(@astrojs/markdown-satteri@0.2.1)(astro@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0))
       '@astrojs/rss':
         specifier: ^4.0.10
         version: 4.0.18
@@ -34,10 +34,10 @@ importers:
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.3.0(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       astro:
         specifier: ^6.4.0
-        version: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
+        version: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -69,6 +69,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.60.0
         version: 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      docx:
+        specifier: ^9.7.1
+        version: 9.7.1
       eslint:
         specifier: ^10.0.0
         version: 10.4.1(jiti@2.7.0)
@@ -84,6 +87,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.5.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
@@ -984,6 +990,9 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1131,6 +1140,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1316,6 +1328,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1412,6 +1427,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docx@9.7.1:
+    resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
+    engines: {node: '>=10'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1576,6 +1595,11 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1618,6 +1642,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1799,6 +1827,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
@@ -1820,6 +1852,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -1878,9 +1913,15 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -1938,6 +1979,10 @@ packages:
     resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
     engines: {node: '>=20'}
     hasBin: true
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2027,6 +2072,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2035,6 +2083,10 @@ packages:
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -2066,8 +2118,15 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2083,6 +2142,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2364,6 +2426,9 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2384,6 +2449,11 @@ packages:
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -2487,6 +2557,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -2572,6 +2645,9 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -2584,6 +2660,9 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2703,6 +2782,9 @@ packages:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -2717,6 +2799,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2738,6 +2824,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2798,6 +2887,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -2825,12 +2917,19 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
@@ -2948,6 +3047,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3242,9 +3344,16 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -3374,13 +3483,13 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.6.3
 
-  '@astrojs/mdx@6.0.1(@astrojs/markdown-satteri@0.2.1)(astro@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0))':
+  '@astrojs/mdx@6.0.1(@astrojs/markdown-satteri@0.2.1)(astro@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4017,12 +4126,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -4064,6 +4173,10 @@ snapshots:
   '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/sax@1.2.7':
     dependencies:
@@ -4265,6 +4378,10 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -4334,7 +4451,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0):
+  astro@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -4386,8 +4503,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -4534,6 +4651,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4631,6 +4750,15 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docx@9.7.1:
+    dependencies:
+      '@types/node': 25.9.1
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.11
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   dom-serializer@2.0.0:
     dependencies:
@@ -4920,6 +5048,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -4968,6 +5098,10 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   extend@3.0.2: {}
 
@@ -5168,6 +5302,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   h3@1.15.11:
     dependencies:
       cookie-es: 1.2.3
@@ -5195,6 +5336,11 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
 
   hasown@2.0.4:
     dependencies:
@@ -5338,7 +5484,11 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -5398,6 +5548,8 @@ snapshots:
   is-docker@3.0.0: {}
 
   is-docker@4.0.0: {}
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -5481,11 +5633,18 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -5516,9 +5675,18 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -5532,6 +5700,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -6058,6 +6230,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -6073,6 +6247,8 @@ snapshots:
   muggle-string@0.4.1: {}
 
   nanoid@3.3.12: {}
+
+  nanoid@5.1.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -6183,6 +6359,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -6260,6 +6438,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
@@ -6267,6 +6447,16 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -6492,6 +6682,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -6518,6 +6710,11 @@ snapshots:
 
   sax@1.6.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.8.1: {}
@@ -6543,6 +6740,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -6639,6 +6838,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -6681,6 +6882,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -6689,6 +6894,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-bom-string@1.0.0: {}
 
   strip-outer@1.0.1:
     dependencies:
@@ -6814,6 +7021,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici-types@7.24.6: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -6910,7 +7119,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6919,15 +7128,15 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.4
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -7083,7 +7292,13 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
   xml-naming@0.1.0: {}
+
+  xml@1.0.1: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.5.0
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -1717,6 +1720,11 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2524,6 +2532,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5059,6 +5077,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6206,6 +6227,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/cv-meta.mjs
+++ b/scripts/cv-meta.mjs
@@ -21,13 +21,15 @@ export function computeCvMeta() {
   let updated = '';
   try {
     updated = execSync(
-      'git log -1 --format=%cs -- src/content/work-en src/content/work-es src/content/profile',
+      'git log -1 --format=%cd --date=short -- src/content/work-en src/content/work-es src/content/profile',
       { encoding: 'utf-8' }
     ).trim();
   } catch {
     // no git or no commits — fall back to today
   }
-  if (!updated) updated = new Date().toISOString().slice(0, 10);
+  if (!updated || !/^\d{4}-\d{2}-\d{2}$/.test(updated)) {
+    updated = new Date().toISOString().slice(0, 10);
+  }
 
   return { hash, updated };
 }

--- a/scripts/cv-meta.mjs
+++ b/scripts/cv-meta.mjs
@@ -1,0 +1,33 @@
+// scripts/cv-meta.mjs
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+
+export function computeCvMeta() {
+  const workDirs = ['src/content/work-en', 'src/content/work-es'];
+  const files = workDirs
+    .flatMap(dir =>
+      readdirSync(dir)
+        .filter(f => f.endsWith('.md'))
+        .sort()
+        .map(f => join(dir, f))
+    )
+    .sort();
+
+  const hashInput = files.map(f => readFileSync(f, 'utf-8')).join('');
+  const hash = createHash('sha256').update(hashInput).digest('hex').slice(0, 8);
+
+  let updated = '';
+  try {
+    updated = execSync(
+      'git log -1 --format=%cs -- src/content/work-en src/content/work-es src/content/profile',
+      { encoding: 'utf-8' }
+    ).trim();
+  } catch {
+    // no git or no commits — fall back to today
+  }
+  if (!updated) updated = new Date().toISOString().slice(0, 10);
+
+  return { hash, updated };
+}

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -1,0 +1,179 @@
+// scripts/generate-docx.mjs
+import {
+  Document, Packer, Paragraph, TextRun, HeadingLevel,
+  AlignmentType, BorderStyle, TabStopPosition, TabStopType,
+} from 'docx';
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import matter from 'gray-matter';
+import { computeCvMeta } from './cv-meta.mjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const profilePublic = require('../src/content/profile/public.json');
+
+// Section labels inlined to avoid TS import issues in plain .mjs
+// If src/cv/sections.ts labels change, update these too.
+const SECTIONS_DATA = {
+  en: { experience: 'Experience', education: 'Education', skills: 'Skills', present: 'Present', updated: 'Updated' },
+  es: { experience: 'Experiencia', education: 'Educación', skills: 'Conocimientos', present: 'Actualidad', updated: 'Actualizado' },
+};
+
+const { hash, updated } = computeCvMeta();
+const distCv = resolve('dist/cv');
+if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
+
+function parseWorkFiles(dir) {
+  return readdirSync(dir)
+    .filter(f => f.endsWith('.md'))
+    .map(f => {
+      const raw = readFileSync(join(dir, f), 'utf-8');
+      return matter(raw).data;
+    })
+    .filter(d => d.include?.cv !== false)
+    .sort((a, b) => {
+      const da = new Date(a.dateStart.split('/').reverse().join('-'));
+      const db = new Date(b.dateStart.split('/').reverse().join('-'));
+      return db - da;
+    });
+}
+
+function parseDate(dateStr) {
+  const [m, d, y] = dateStr.split('/').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function formatDate(dateStr, locale) {
+  const d = parseDate(dateStr);
+  return d.toLocaleString(locale, { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+function buildDoc(lang) {
+  const s = SECTIONS_DATA[lang];
+  const locale = lang === 'en' ? 'en' : 'es';
+  const workDir = `src/content/work-${lang}`;
+  const entries = parseWorkFiles(workDir);
+
+  const children = [];
+
+  // Header
+  children.push(
+    new Paragraph({
+      children: [new TextRun({ text: profilePublic.name, bold: true, size: 36 })],
+      spacing: { after: 40 },
+    }),
+    new Paragraph({
+      children: [new TextRun({ text: profilePublic.title, size: 20, color: '444444' })],
+      spacing: { after: 40 },
+    }),
+    new Paragraph({
+      children: [
+        new TextRun({ text: profilePublic.email, size: 18 }),
+        new TextRun({ text: '  ·  ' + profilePublic.location, size: 18, color: '444444' }),
+        new TextRun({ text: '  ·  ' + profilePublic.linkedin.replace('https://', ''), size: 18, color: '444444' }),
+      ],
+      spacing: { after: 200 },
+    }),
+  );
+
+  // Experience section
+  children.push(
+    new Paragraph({
+      text: s.experience.toUpperCase(),
+      heading: HeadingLevel.HEADING_2,
+      spacing: { before: 200, after: 80 },
+      border: { bottom: { style: BorderStyle.SINGLE, size: 6, color: '111111' } },
+    }),
+  );
+
+  for (const entry of entries) {
+    const start = formatDate(entry.dateStart, locale);
+    const endStr = ['current', 'actualidad'].includes((entry.dateEnd ?? '').toLowerCase())
+      ? s.present
+      : formatDate(entry.dateEnd, locale);
+    const dateRange = `${start} – ${endStr}`;
+
+    children.push(
+      new Paragraph({
+        children: [
+          new TextRun({ text: entry.company, bold: true, size: 20 }),
+          new TextRun({ text: '\t' + dateRange, size: 18, color: '444444' }),
+        ],
+        tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }],
+        spacing: { before: 120, after: 20 },
+      }),
+      new Paragraph({
+        children: [
+          new TextRun({
+            text: entry.role + (entry.location ? ' · ' + entry.location : ''),
+            size: 18, color: '333333',
+          }),
+        ],
+        spacing: { after: 40 },
+      }),
+    );
+
+    if (entry.bullets && entry.bullets.length > 0) {
+      for (const bullet of entry.bullets) {
+        children.push(
+          new Paragraph({
+            children: [new TextRun({ text: bullet, size: 18 })],
+            bullet: { level: 0 },
+            spacing: { after: 20 },
+          }),
+        );
+      }
+    }
+  }
+
+  // Skills section
+  if (entries.some(e => e.tech && e.tech.length > 0)) {
+    const allTech = [...new Set(entries.flatMap(e => e.tech ?? []))];
+    children.push(
+      new Paragraph({
+        text: s.skills.toUpperCase(),
+        heading: HeadingLevel.HEADING_2,
+        spacing: { before: 200, after: 80 },
+        border: { bottom: { style: BorderStyle.SINGLE, size: 6, color: '111111' } },
+      }),
+      new Paragraph({
+        children: [new TextRun({ text: allTech.join(' · '), size: 18 })],
+        spacing: { after: 80 },
+      }),
+    );
+  }
+
+  // Updated date
+  if (updated) {
+    const d = new Date(updated + 'T00:00:00Z');
+    const dateLabel = lang === 'en'
+      ? s.updated + ' ' + d.toLocaleString('en', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+      : s.updated + ' ' + d.toLocaleString('es', { month: 'long', timeZone: 'UTC' }) + ' de ' + d.getUTCFullYear();
+    children.push(
+      new Paragraph({
+        children: [new TextRun({ text: dateLabel, size: 16, color: '888888' })],
+        alignment: AlignmentType.RIGHT,
+        spacing: { before: 200 },
+      }),
+    );
+  }
+
+  return new Document({
+    sections: [{
+      properties: {
+        page: {
+          margin: { top: 910, bottom: 910, left: 793, right: 793 }, // ~16mm / ~14mm in TWIPs
+        },
+      },
+      children,
+    }],
+  });
+}
+
+for (const lang of ['en', 'es']) {
+  const doc = buildDoc(lang);
+  const buffer = await Packer.toBuffer(doc);
+  const outPath = join(distCv, `javier-zapata-${lang}-${hash}.docx`);
+  writeFileSync(outPath, buffer);
+  console.log(`Generated: ${outPath}`);
+}

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -48,7 +48,11 @@ function parseWorkFiles(dir) {
     });
 }
 
-function parseDate(dateStr) {
+function parseDate(dateVal) {
+  if (dateVal instanceof Date) {
+    return dateVal;
+  }
+  const dateStr = String(dateVal || '');
   const [m, d, y] = dateStr.split('/').map(Number);
   const date = new Date(Date.UTC(y, m - 1, d));
   if (isNaN(date.getTime())) {
@@ -118,7 +122,7 @@ function buildDoc(lang) {
 
   for (const entry of entries) {
     const start = formatDate(entry.dateStart, locale);
-    const endStr = ['current', 'actualidad'].includes((entry.dateEnd ?? '').trim().toLowerCase())
+    const endStr = ['current', 'actualidad'].includes(String(entry.dateEnd ?? '').trim().toLowerCase())
       ? s.present
       : formatDate(entry.dateEnd, locale);
     const dateRange = `${start} – ${endStr}`;

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -7,7 +7,10 @@ import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, copyFi
 import { join, resolve } from 'node:path';
 import matter from 'gray-matter';
 import { computeCvMeta } from './cv-meta.mjs';
-const profilePublic = JSON.parse(readFileSync(resolve('src/content/profile/public.json'), 'utf-8'));
+const profilePath = existsSync(resolve('src/content/profile/full.json'))
+  ? resolve('src/content/profile/full.json')
+  : resolve('src/content/profile/public.json');
+const profilePublic = JSON.parse(readFileSync(profilePath, 'utf-8'));
 
 // Section labels inlined to avoid TS import issues in plain .mjs
 // If src/cv/sections.ts labels change, update these too.
@@ -26,8 +29,16 @@ function parseWorkFiles(dir) {
   return readdirSync(dir)
     .filter(f => f.endsWith('.md'))
     .map(f => {
-      const raw = readFileSync(join(dir, f), 'utf-8');
-      return matter(raw).data;
+      const filePath = join(dir, f);
+      const raw = readFileSync(filePath, 'utf-8');
+      const data = matter(raw).data;
+      if (!data.dateStart) {
+        throw new Error(`Missing "dateStart" in frontmatter of ${filePath}`);
+      }
+      if (!data.dateEnd) {
+        throw new Error(`Missing "dateEnd" in frontmatter of ${filePath}`);
+      }
+      return data;
     })
     .filter(d => d.include?.cv !== false)
     .sort((a, b) => {
@@ -63,6 +74,9 @@ function buildDoc(lang) {
   const contactChildren = [
     new TextRun({ text: email, size: 18 }),
   ];
+  if (profilePublic.phone) {
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.phone, size: 18, color: '444444' }));
+  }
   if (profilePublic.location) {
     contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.location, size: 18, color: '444444' }));
   }

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -85,10 +85,10 @@ function buildDoc(lang) {
     contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.location, size: 18, color: '444444' }));
   }
   if (profilePublic.linkedin) {
-    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.linkedin.replace('https://', ''), size: 18, color: '444444' }));
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.linkedin.replace(/^https?:\/\/(www\.)?/, ''), size: 18, color: '444444' }));
   }
   if (profilePublic.github) {
-    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.github.replace('https://', ''), size: 18, color: '444444' }));
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.github.replace(/^https?:\/\/(www\.)?/, ''), size: 18, color: '444444' }));
   }
 
   children.push(
@@ -135,7 +135,7 @@ function buildDoc(lang) {
       new Paragraph({
         children: [
           new TextRun({
-            text: entry.role + (entry.location ? ' · ' + entry.location : ''),
+            text: (entry.role || '') + (entry.location ? ' · ' + entry.location : ''),
             size: 18, color: '333333',
           }),
         ],
@@ -143,7 +143,7 @@ function buildDoc(lang) {
       }),
     );
 
-    if (entry.bullets && entry.bullets.length > 0) {
+    if (Array.isArray(entry.bullets) && entry.bullets.length > 0) {
       for (const bullet of entry.bullets) {
         children.push(
           new Paragraph({
@@ -172,8 +172,8 @@ function buildDoc(lang) {
       children.push(
         new Paragraph({
           children: [
-            new TextRun({ text: edu.institution, bold: true, size: 20 }),
-            new TextRun({ text: '\t' + edu.year, size: 18, color: '444444' }),
+            new TextRun({ text: edu.institution || '', bold: true, size: 20 }),
+            new TextRun({ text: '\t' + (edu.year || ''), size: 18, color: '444444' }),
           ],
           tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }],
           spacing: { before: 120, after: 20 },
@@ -181,7 +181,7 @@ function buildDoc(lang) {
         new Paragraph({
           children: [
             new TextRun({
-              text: edu.degree,
+              text: edu.degree || '',
               size: 18, color: '333333',
             }),
           ],
@@ -192,8 +192,8 @@ function buildDoc(lang) {
   }
 
   // Skills section
-  if (entries.some(e => e.tech && e.tech.length > 0)) {
-    const allTech = [...new Set(entries.flatMap(e => e.tech ?? []))];
+  if (entries.some(e => Array.isArray(e.tech) && e.tech.length > 0)) {
+    const allTech = [...new Set(entries.flatMap(e => Array.isArray(e.tech) ? e.tech : []))];
     children.push(
       new Paragraph({
         text: s.skills.toUpperCase(),

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -50,7 +50,11 @@ function parseWorkFiles(dir) {
 
 function parseDate(dateStr) {
   const [m, d, y] = dateStr.split('/').map(Number);
-  return new Date(Date.UTC(y, m - 1, d));
+  const date = new Date(Date.UTC(y, m - 1, d));
+  if (isNaN(date.getTime())) {
+    throw new Error('Invalid date format: "' + dateStr + '". Expected MM/DD/YYYY');
+  }
+  return date;
 }
 
 function formatDate(dateStr, locale) {
@@ -209,7 +213,7 @@ function buildDoc(lang) {
     const d = new Date(updated + 'T00:00:00Z');
     const dateLabel = lang === 'en'
       ? s.updated + ' ' + d.toLocaleString('en', { month: 'long', year: 'numeric', timeZone: 'UTC' })
-      : s.updated + ' ' + d.toLocaleString('es', { month: 'long', timeZone: 'UTC' }) + ' de ' + d.getUTCFullYear();
+      : s.updated + ' en ' + d.toLocaleString('es', { month: 'long', timeZone: 'UTC' }) + ' de ' + d.getUTCFullYear();
     children.push(
       new Paragraph({
         children: [new TextRun({ text: dateLabel, size: 16, color: '888888' })],

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -7,10 +7,7 @@ import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, copyFi
 import { join, resolve } from 'node:path';
 import matter from 'gray-matter';
 import { computeCvMeta } from './cv-meta.mjs';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const profilePublic = require('../src/content/profile/public.json');
+const profilePublic = JSON.parse(readFileSync(resolve('src/content/profile/public.json'), 'utf-8'));
 
 // Section labels inlined to avoid TS import issues in plain .mjs
 // If src/cv/sections.ts labels change, update these too.
@@ -34,8 +31,8 @@ function parseWorkFiles(dir) {
     })
     .filter(d => d.include?.cv !== false)
     .sort((a, b) => {
-      const da = new Date(a.dateStart.split('/').reverse().join('-'));
-      const db = new Date(b.dateStart.split('/').reverse().join('-'));
+      const da = parseDate(a.dateStart);
+      const db = parseDate(b.dateStart);
       return db - da;
     });
 }
@@ -59,21 +56,34 @@ function buildDoc(lang) {
   const children = [];
 
   // Header
+  const name = profilePublic.name || '';
+  const title = profilePublic.title || '';
+  const email = profilePublic.email || '';
+
+  const contactChildren = [
+    new TextRun({ text: email, size: 18 }),
+  ];
+  if (profilePublic.location) {
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.location, size: 18, color: '444444' }));
+  }
+  if (profilePublic.linkedin) {
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.linkedin.replace('https://', ''), size: 18, color: '444444' }));
+  }
+  if (profilePublic.github) {
+    contactChildren.push(new TextRun({ text: '  ·  ' + profilePublic.github.replace('https://', ''), size: 18, color: '444444' }));
+  }
+
   children.push(
     new Paragraph({
-      children: [new TextRun({ text: profilePublic.name, bold: true, size: 36 })],
+      children: [new TextRun({ text: name, bold: true, size: 36 })],
       spacing: { after: 40 },
     }),
     new Paragraph({
-      children: [new TextRun({ text: profilePublic.title, size: 20, color: '444444' })],
+      children: [new TextRun({ text: title, size: 20, color: '444444' })],
       spacing: { after: 40 },
     }),
     new Paragraph({
-      children: [
-        new TextRun({ text: profilePublic.email, size: 18 }),
-        new TextRun({ text: '  ·  ' + profilePublic.location, size: 18, color: '444444' }),
-        new TextRun({ text: '  ·  ' + profilePublic.linkedin.replace('https://', ''), size: 18, color: '444444' }),
-      ],
+      children: contactChildren,
       spacing: { after: 200 },
     }),
   );
@@ -125,6 +135,41 @@ function buildDoc(lang) {
           }),
         );
       }
+    }
+  }
+
+  // Education section
+  const education = profilePublic.education ?? [];
+  if (education.length > 0) {
+    children.push(
+      new Paragraph({
+        text: s.education.toUpperCase(),
+        heading: HeadingLevel.HEADING_2,
+        spacing: { before: 200, after: 80 },
+        border: { bottom: { style: BorderStyle.SINGLE, size: 6, color: '111111' } },
+      }),
+    );
+
+    for (const edu of education) {
+      children.push(
+        new Paragraph({
+          children: [
+            new TextRun({ text: edu.institution, bold: true, size: 20 }),
+            new TextRun({ text: '\t' + edu.year, size: 18, color: '444444' }),
+          ],
+          tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }],
+          spacing: { before: 120, after: 20 },
+        }),
+        new Paragraph({
+          children: [
+            new TextRun({
+              text: edu.degree,
+              size: 18, color: '333333',
+            }),
+          ],
+          spacing: { after: 40 },
+        }),
+      );
     }
   }
 

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -118,7 +118,7 @@ function buildDoc(lang) {
 
   for (const entry of entries) {
     const start = formatDate(entry.dateStart, locale);
-    const endStr = ['current', 'actualidad'].includes((entry.dateEnd ?? '').toLowerCase())
+    const endStr = ['current', 'actualidad'].includes((entry.dateEnd ?? '').trim().toLowerCase())
       ? s.present
       : formatDate(entry.dateEnd, locale);
     const dateRange = `${start} – ${endStr}`;

--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -3,7 +3,7 @@ import {
   Document, Packer, Paragraph, TextRun, HeadingLevel,
   AlignmentType, BorderStyle, TabStopPosition, TabStopType,
 } from 'docx';
-import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import matter from 'gray-matter';
 import { computeCvMeta } from './cv-meta.mjs';
@@ -21,7 +21,9 @@ const SECTIONS_DATA = {
 
 const { hash, updated } = computeCvMeta();
 const distCv = resolve('dist/cv');
+const publicCv = resolve('public/cv');
 if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
+if (!existsSync(publicCv)) mkdirSync(publicCv, { recursive: true });
 
 function parseWorkFiles(dir) {
   return readdirSync(dir)
@@ -175,5 +177,7 @@ for (const lang of ['en', 'es']) {
   const buffer = await Packer.toBuffer(doc);
   const outPath = join(distCv, `javier-zapata-${lang}-${hash}.docx`);
   writeFileSync(outPath, buffer);
+  // Also copy to public/cv/ so `pnpm dev` can serve it
+  copyFileSync(outPath, join(publicCv, `javier-zapata-${lang}-${hash}.docx`));
   console.log(`Generated: ${outPath}`);
 }

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -3,24 +3,34 @@ import { chromium } from 'playwright';
 import { resolve, join } from 'node:path';
 import { mkdirSync, existsSync, copyFileSync } from 'node:fs';
 import { computeCvMeta } from './cv-meta.mjs';
+import { pathToFileURL } from 'node:url';
 
 const { hash } = computeCvMeta();
 const distCv = resolve('dist/cv');
 const publicCv = resolve('public/cv');
-if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
-if (!existsSync(publicCv)) mkdirSync(publicCv, { recursive: true });
 
 const configs = [
   { lang: 'en', htmlPath: resolve('dist/en/cv/index.html') },
   { lang: 'es', htmlPath: resolve('dist/es/cv/index.html') },
 ];
 
+// Verify files exist first
+for (const { htmlPath } of configs) {
+  if (!existsSync(htmlPath)) {
+    console.error('Error: HTML file not found at ' + htmlPath + '. Did you run pnpm build first?');
+    process.exit(1);
+  }
+}
+
+if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
+if (!existsSync(publicCv)) mkdirSync(publicCv, { recursive: true });
+
 const browser = await chromium.launch();
 
 for (const { lang, htmlPath } of configs) {
   const outPath = join(distCv, `javier-zapata-${lang}-${hash}.pdf`);
   const page = await browser.newPage();
-  await page.goto('file://' + htmlPath);
+  await page.goto(pathToFileURL(htmlPath).href);
   await page.evaluate(() => document.fonts.ready);
   await page.pdf({
     path: outPath,

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -1,0 +1,34 @@
+// scripts/generate-pdf.mjs
+import { chromium } from 'playwright';
+import { resolve, join } from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs';
+import { computeCvMeta } from './cv-meta.mjs';
+
+const { hash } = computeCvMeta();
+const distCv = resolve('dist/cv');
+if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
+
+const configs = [
+  { lang: 'en', htmlPath: resolve('dist/en/cv/index.html') },
+  { lang: 'es', htmlPath: resolve('dist/es/cv/index.html') },
+];
+
+const browser = await chromium.launch();
+
+for (const { lang, htmlPath } of configs) {
+  const outPath = join(distCv, `javier-zapata-${lang}-${hash}.pdf`);
+  const page = await browser.newPage();
+  await page.goto('file://' + htmlPath);
+  await page.evaluate(() => document.fonts.ready);
+  await page.pdf({
+    path: outPath,
+    printBackground: true,
+    format: 'A4',
+    displayHeaderFooter: false,
+    margin: { top: '16mm', bottom: '16mm', left: '14mm', right: '14mm' },
+  });
+  await page.close();
+  console.log(`Generated: ${outPath}`);
+}
+
+await browser.close();

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -1,12 +1,14 @@
 // scripts/generate-pdf.mjs
 import { chromium } from 'playwright';
 import { resolve, join } from 'node:path';
-import { mkdirSync, existsSync } from 'node:fs';
+import { mkdirSync, existsSync, copyFileSync } from 'node:fs';
 import { computeCvMeta } from './cv-meta.mjs';
 
 const { hash } = computeCvMeta();
 const distCv = resolve('dist/cv');
+const publicCv = resolve('public/cv');
 if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
+if (!existsSync(publicCv)) mkdirSync(publicCv, { recursive: true });
 
 const configs = [
   { lang: 'en', htmlPath: resolve('dist/en/cv/index.html') },
@@ -28,6 +30,9 @@ for (const { lang, htmlPath } of configs) {
     margin: { top: '16mm', bottom: '16mm', left: '14mm', right: '14mm' },
   });
   await page.close();
+  // Also copy to public/cv/ so `pnpm dev` can serve it
+  const publicPath = join(publicCv, `javier-zapata-${lang}-${hash}.pdf`);
+  copyFileSync(outPath, publicPath);
   console.log(`Generated: ${outPath}`);
 }
 

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -26,24 +26,25 @@ if (!existsSync(distCv)) mkdirSync(distCv, { recursive: true });
 if (!existsSync(publicCv)) mkdirSync(publicCv, { recursive: true });
 
 const browser = await chromium.launch();
-
-for (const { lang, htmlPath } of configs) {
-  const outPath = join(distCv, `javier-zapata-${lang}-${hash}.pdf`);
-  const page = await browser.newPage();
-  await page.goto(pathToFileURL(htmlPath).href);
-  await page.evaluate(() => document.fonts.ready);
-  await page.pdf({
-    path: outPath,
-    printBackground: true,
-    format: 'A4',
-    displayHeaderFooter: false,
-    margin: { top: '16mm', bottom: '16mm', left: '14mm', right: '14mm' },
-  });
-  await page.close();
-  // Also copy to public/cv/ so `pnpm dev` can serve it
-  const publicPath = join(publicCv, `javier-zapata-${lang}-${hash}.pdf`);
-  copyFileSync(outPath, publicPath);
-  console.log(`Generated: ${outPath}`);
+try {
+  for (const { lang, htmlPath } of configs) {
+    const outPath = join(distCv, `javier-zapata-${lang}-${hash}.pdf`);
+    const page = await browser.newPage();
+    await page.goto(pathToFileURL(htmlPath).href);
+    await page.evaluate(() => document.fonts.ready);
+    await page.pdf({
+      path: outPath,
+      printBackground: true,
+      format: 'A4',
+      displayHeaderFooter: false,
+      margin: { top: '16mm', bottom: '16mm', left: '14mm', right: '14mm' },
+    });
+    await page.close();
+    // Also copy to public/cv/ so `pnpm dev` can serve it
+    const publicPath = join(publicCv, `javier-zapata-${lang}-${hash}.pdf`);
+    copyFileSync(outPath, publicPath);
+    console.log(`Generated: ${outPath}`);
+  }
+} finally {
+  await browser.close();
 }
-
-await browser.close();

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ const labels = locale === "es"
         <BackToTop />
       </div>
     </div>
-    <div class="flex justify-between items-center">
+    <div class="flex flex-wrap justify-between items-center gap-y-2">
       <div class="flex gap-3 items-center">
         <div>
           &copy; {year} {`|`} {SITE.NAME}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -46,7 +46,7 @@ const workSchema = z.object({
   include: z.object({
     cv: z.boolean().default(true),
     web: z.boolean().default(true),
-  }).optional(),
+  }).default({ cv: true, web: true }),
 });
 
 const workEs = defineCollection({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -40,6 +40,13 @@ const workSchema = z.object({
   dateEnd: z.string().transform(val =>
     ["current", "actualidad"].includes(val.trim().toLowerCase()) ? val : parseWorkDate(val)
   ),
+  location: z.string().optional(),
+  bullets: z.array(z.string()).optional(),
+  tech: z.array(z.string()).optional(),
+  include: z.object({
+    cv: z.boolean().default(true),
+    web: z.boolean().default(true),
+  }).optional(),
 });
 
 const workEs = defineCollection({

--- a/src/content/profile/public.json
+++ b/src/content/profile/public.json
@@ -1,0 +1,10 @@
+{
+  "name": "Javier Zapata",
+  "title": "Tech Lead & Software Developer",
+  "email": "javierzapata82@gmail.com",
+  "location": "Madrid, Spain",
+  "linkedin": "https://www.linkedin.com/in/jzfgo",
+  "github": "https://github.com/jzfgo",
+  "website": "https://javi.io",
+  "education": []
+}

--- a/src/content/work-en/bahiazul.md
+++ b/src/content/work-en/bahiazul.md
@@ -1,8 +1,20 @@
 ---
 company: "Bahiazul Resort"
 role: "Tech Lead & Creative Director"
+location: "Madrid, Spain"
 dateStart: "04/01/2020"
 dateEnd: "03/01/2021"
+bullets:
+  - "Redesigned resort website with Next.js, TypeScript, and Firebase, shipping SSR hosting with MDX-driven content"
+  - "Built an internal Design System used across all web and mobile products, ensuring visual consistency"
+  - "Delivered a Svelte-based mobile-first Digital Kiosk SPA, hosted on Firebase"
+tech:
+  - "Next.js"
+  - "TypeScript"
+  - "Firebase"
+  - "Svelte"
+  - "Design Systems"
+  - "MDX"
 ---
 
 After Piensa Diferente went down because of the COVID-19 pandemic, I was approached by Bahiazul to join them and keep working on their projects.

--- a/src/content/work-en/fly-fut.md
+++ b/src/content/work-en/fly-fut.md
@@ -1,8 +1,21 @@
 ---
 company: "Fly-Fut"
 role: "Tech Lead"
+location: "Madrid, Spain"
 dateStart: "04/01/2021"
 dateEnd: "10/01/2022"
+bullets:
+  - "Led architecture and development of the consumer platform (Fly-Fut Ligas): backend, fully automated AI video pipeline for drone-recorded football matches, management tools, and mobile app"
+  - "Designed and prototyped an iPad app for autonomous drone control in football training sessions"
+  - "Designed Fly-Fut Pro suite: iPad recording app and tactical analysis tool"
+tech:
+  - "Node.js"
+  - "TypeScript"
+  - "Swift/iOS"
+  - "AI/ML pipelines"
+  - "video encoding"
+  - "cloud infrastructure"
+  - "PostgreSQL"
 ---
 
 Fly-Fut is the first company in the world to protocolize the recording of football with drones, assisted by AI.

--- a/src/content/work-en/interacso.md
+++ b/src/content/work-en/interacso.md
@@ -1,8 +1,23 @@
 ---
 company: "Interacso"
 role: "Tech Lead"
+location: "Madrid, Spain"
 dateStart: "11/01/2022"
 dateEnd: "Current"
+bullets:
+  - "Lead software architecture, cloud infrastructure design, and technical decision-making for clients including IKEA, Clear Channel, Grupo Porcelanosa, and Sony Pictures Spain"
+  - "Bootstrap new projects: frameworks, tooling, CI/CD pipelines, and test suites so teams hit the ground running"
+  - "Lead team through trust and mentorship: write production-quality code as a concrete standard, involve the team in technical decisions"
+tech:
+  - "TypeScript"
+  - "React"
+  - "Next.js"
+  - "Node.js"
+  - "AWS"
+  - "GCP"
+  - "PostgreSQL"
+  - "architecture"
+  - "team leadership"
 ---
 
 Interacso specializes in custom web and mobile application development, offering services in software development, UX/UI design, and digital strategy.

--- a/src/content/work-en/neolabels.md
+++ b/src/content/work-en/neolabels.md
@@ -1,8 +1,21 @@
 ---
 company: "Neo Labels"
 role: "Designer → R&D Consultant"
+location: "Madrid, Spain"
 dateStart: "05/01/2006"
 dateEnd: "06/01/2013"
+bullets:
+  - "Delivered end-to-end product work for 7 years: UX/UI design through full-stack development for digital campaigns and applications"
+  - "Designed and built products for brands including Ferran Adrià (Adrià en casa), Telefónica Movistar, and Aramón"
+  - "Led R&D and frontend mobile development during the agency's final growth stage before its acquisition by IPG Mediabrands"
+tech:
+  - "HTML"
+  - "CSS"
+  - "JavaScript"
+  - "PHP"
+  - "MySQL"
+  - "mobile web"
+  - "UX/UI"
 ---
 
 Neo Labels was an online marketing agency focused on helping brands enter the digital age of media, social networks, and applications in Spain. Born from the experience gained through Sharemusic!, it was acquired by IPG Mediabrands in April 2021.

--- a/src/content/work-en/piensa-diferente.md
+++ b/src/content/work-en/piensa-diferente.md
@@ -1,8 +1,20 @@
 ---
 company: "Piensa Diferente"
 role: "Head of Technology"
+location: "Madrid, Spain"
 dateStart: "07/01/2013"
 dateEnd: "03/01/2020"
+bullets:
+  - "Co-founded and led technology for a hospitality startup serving small resorts and B&Bs for 7 years"
+  - "Designed and built a custom Property Management System (PMS) and client websites end-to-end"
+  - "Owned cloud architecture, IT infrastructure, and coordination of external contractors"
+tech:
+  - "PHP"
+  - "JavaScript"
+  - "MySQL"
+  - "AWS"
+  - "UX/UI"
+  - "cloud architecture"
 ---
 
 Piensa Diferente was an early startup that provided consulting services to small to medium-sized resorts and B&Bs. It specialized in offering tailored yet affordable solutions to enable its clients to compete directly with the big hospitality chains through technology and innovation.

--- a/src/content/work-en/sharemusic.md
+++ b/src/content/work-en/sharemusic.md
@@ -1,8 +1,20 @@
 ---
 company: "Sharemusic!"
 role: "Designer → Creative Director"
+location: "Madrid, Spain"
 dateStart: "05/01/2006"
 dateEnd: "12/01/2010"
+bullets:
+  - "Co-built atopechavalote.com, one of Spain's first social networks for nightlife, reaching 25,000 registered users"
+  - "Evolved from designer to Creative Director: led branding, UX/UI design, and digital strategy"
+  - "Secured event sponsorships with Sony PlayStation, BBVA, and Everlast"
+tech:
+  - "HTML"
+  - "CSS"
+  - "JavaScript"
+  - "Flash"
+  - "UX/UI"
+  - "branding"
 ---
 
 Sharemusic! is a nightlife event organizer in Madrid. It pioneered the social networking revolution in Spain with atopechavalote.com (2005–2010), reaching 25,000 registered users.

--- a/src/content/work-es/bahiazul.md
+++ b/src/content/work-es/bahiazul.md
@@ -1,8 +1,20 @@
 ---
 company: "Bahiazul Resort"
 role: "Tech Lead & Creative Director"
+location: "Madrid, España"
 dateStart: "04/01/2020"
 dateEnd: "03/01/2021"
+bullets:
+  - "Rediseñé la web del resort con Next.js, TypeScript y Firebase, incluyendo SSR y contenido gestionado con MDX"
+  - "Construí un Sistema de Diseño interno usado en todos los productos web y móviles para garantizar coherencia visual"
+  - "Entregué un Quiosco Digital SPA basado en Svelte, mobile-first, alojado en Firebase"
+tech:
+  - "Next.js"
+  - "TypeScript"
+  - "Firebase"
+  - "Svelte"
+  - "Design Systems"
+  - "MDX"
 ---
 
 Después de que Piensa Diferente cerrara debido a la pandemia de COVID-19, Bahiazul me propuso unirme a ellos para seguir trabajando en sus proyectos.

--- a/src/content/work-es/fly-fut.md
+++ b/src/content/work-es/fly-fut.md
@@ -1,8 +1,21 @@
 ---
 company: "Fly-Fut"
 role: "Tech Lead"
+location: "Madrid, España"
 dateStart: "04/01/2021"
 dateEnd: "10/01/2022"
+bullets:
+  - "Lideré la arquitectura y el desarrollo de la plataforma de consumo (Fly-Fut Ligas): backend, pipeline de vídeo automatizado con IA para partidos grabados con drones, herramientas de gestión y app móvil"
+  - "Diseñé y prototipé una app iPad para el control autónomo de drones en entrenamientos de fútbol"
+  - "Diseñé la suite Fly-Fut Pro: app de grabación para iPad y herramienta de análisis táctico"
+tech:
+  - "Node.js"
+  - "TypeScript"
+  - "Swift/iOS"
+  - "pipelines de IA/ML"
+  - "encoding de vídeo"
+  - "infraestructura cloud"
+  - "PostgreSQL"
 ---
 
 Fly-Fut es la primera empresa del mundo en protocolizar la grabación de fútbol con drones, asistida por IA.

--- a/src/content/work-es/interacso.md
+++ b/src/content/work-es/interacso.md
@@ -1,8 +1,23 @@
 ---
 company: "Interacso"
 role: "Tech Lead"
+location: "Madrid, España"
 dateStart: "11/01/2022"
 dateEnd: "Actualidad"
+bullets:
+  - "Lidero la arquitectura de software, diseño de infraestructura cloud y toma de decisiones técnicas para clientes como IKEA, Clear Channel, Grupo Porcelanosa y Sony Pictures Spain"
+  - "Arranco nuevos proyectos: frameworks, tooling, pipelines CI/CD y suites de tests para que los equipos arranquen desde el primer día"
+  - "Dirijo el equipo con confianza y mentoría: escribo código de producción como estándar concreto e involucro al equipo en las decisiones técnicas"
+tech:
+  - "TypeScript"
+  - "React"
+  - "Next.js"
+  - "Node.js"
+  - "AWS"
+  - "GCP"
+  - "PostgreSQL"
+  - "arquitectura"
+  - "liderazgo técnico"
 ---
 
 Interacso se especializa en el desarrollo de aplicaciones web y móviles personalizadas, ofreciendo servicios de desarrollo de software, diseño UX/UI y estrategia digital.

--- a/src/content/work-es/neolabels.md
+++ b/src/content/work-es/neolabels.md
@@ -1,8 +1,21 @@
 ---
 company: "Neo Labels"
-role: "Diseñador → Consultor I+D"
+role: "Diseñador → Consultor de I+D"
+location: "Madrid, España"
 dateStart: "05/01/2006"
 dateEnd: "06/01/2013"
+bullets:
+  - "Desarrollé productos de extremo a extremo durante 7 años: desde diseño UX/UI hasta desarrollo full-stack para campañas y aplicaciones digitales"
+  - "Diseñé y construí productos para marcas como Ferran Adrià (Adrià en casa), Telefónica Movistar y Aramón"
+  - "Lideré I+D y desarrollo frontend móvil en la última etapa de crecimiento de la agencia, antes de su adquisición por IPG Mediabrands"
+tech:
+  - "HTML"
+  - "CSS"
+  - "JavaScript"
+  - "PHP"
+  - "MySQL"
+  - "web móvil"
+  - "UX/UI"
 ---
 
 Neo Labels fue una agencia de marketing online enfocada en ayudar a las marcas a entrar en la era de los medios digitales, redes sociales y aplicaciones en España. Nacida de la experiencia obtenida a través de Sharemusic!, fue adquirida por IPG Mediabrands en abril de 2021.

--- a/src/content/work-es/piensa-diferente.md
+++ b/src/content/work-es/piensa-diferente.md
@@ -1,8 +1,20 @@
 ---
 company: "Piensa Diferente"
-role: "Director de Tecnología"
+role: "Head of Technology"
+location: "Madrid, España"
 dateStart: "07/01/2013"
 dateEnd: "03/01/2020"
+bullets:
+  - "Cofundé y lideré la tecnología de una startup hostelera durante 7 años, orientada a pequeños resorts y casas rurales"
+  - "Diseñé y construí de extremo a extremo un Sistema de Gestión de Propiedades (PMS) y webs para clientes"
+  - "Gestioné arquitectura cloud, infraestructura IT y coordinación de desarrolladores externos"
+tech:
+  - "PHP"
+  - "JavaScript"
+  - "MySQL"
+  - "AWS"
+  - "UX/UI"
+  - "arquitectura cloud"
 ---
 
 Piensa Diferente fue una joven startup que ofrecía servicios de consultoría a pequeños y medianos complejos turísticos y establecimientos B&B. Se especializó en ofrecer soluciones personalizadas pero asequibles para permitir a sus clientes competir directamente con las grandes cadenas hoteleras a través de la tecnología y la innovación.

--- a/src/content/work-es/sharemusic.md
+++ b/src/content/work-es/sharemusic.md
@@ -1,8 +1,20 @@
 ---
 company: "Sharemusic!"
 role: "Diseñador → Director Creativo"
+location: "Madrid, España"
 dateStart: "05/01/2006"
 dateEnd: "12/01/2010"
+bullets:
+  - "Coconstruí atopechavalote.com, una de las primeras redes sociales de ocio nocturno en España, con 25.000 usuarios registrados"
+  - "Evolucioné de diseñador a Director Creativo: lideré branding, diseño UX/UI y estrategia digital"
+  - "Conseguí patrocinios de eventos con Sony PlayStation, BBVA y Everlast"
+tech:
+  - "HTML"
+  - "CSS"
+  - "JavaScript"
+  - "Flash"
+  - "UX/UI"
+  - "branding"
 ---
 
 Sharemusic! es una productora de eventos y espectáculos musicales en Madrid. Fue pionera en la revolución de las redes sociales en España con atopechavalote.com (2005–2010), que alcanzó los 25.000 usuarios registrados.

--- a/src/cv/sections.ts
+++ b/src/cv/sections.ts
@@ -1,0 +1,18 @@
+export const SECTIONS = {
+  en: {
+    experience: 'Experience',
+    education: 'Education',
+    skills: 'Skills',
+    updated: 'Updated',
+    present: 'Present',
+  },
+  es: {
+    experience: 'Experiencia',
+    education: 'Educación',
+    skills: 'Conocimientos',
+    updated: 'Actualizado',
+    present: 'Actualidad',
+  },
+} as const;
+
+export type Lang = keyof typeof SECTIONS;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,15 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 
+interface ImportMetaEnv {
+  readonly PUBLIC_CV_HASH: string;
+  readonly PUBLIC_CV_UPDATED: string;
+}
+
 interface Window {
   themeInitialized?: boolean;
   gtmInitialized?: boolean;
   dataLayer?: Record<string, unknown>[];
   appInitialized?: boolean;
 }
+

--- a/src/pages/en/cv/index.astro
+++ b/src/pages/en/cv/index.astro
@@ -97,8 +97,8 @@ const education = (profile.education as unknown as EduEntry[]) ?? [];
     {profile.email}
     {profile.phone && <span> · {profile.phone}</span>}
     {profile.location && <span> · {profile.location}</span>}
-    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
-    {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}
+    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace(/^https?:\/\/(www\.)?/, '')}</a></span>}
+    {profile.github && <span> · <a href={profile.github}>{profile.github.replace(/^https?:\/\/(www\.)?/, '')}</a></span>}
   </p>
 
   <h2>{s.experience}</h2>

--- a/src/pages/en/cv/index.astro
+++ b/src/pages/en/cv/index.astro
@@ -7,7 +7,7 @@ const lang = 'en' as const;
 const s = SECTIONS[lang];
 
 const work = (await getCollection('work-en'))
-  .filter(e => e.data.include?.cv !== false)
+  .filter(e => e.data.include.cv)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
 
 function formatDate(d: Date): string {
@@ -33,7 +33,7 @@ const updatedLabel = cvUpdated
 const allTech = [...new Set(work.flatMap(e => e.data.tech ?? []))];
 
 type EduEntry = { institution: string; degree: string; year: string };
-const education = (profile.education as unknown as EduEntry[]);
+const education = (profile.education as unknown as EduEntry[]) ?? [];
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/src/pages/en/cv/index.astro
+++ b/src/pages/en/cv/index.astro
@@ -1,7 +1,17 @@
 ---
 import { getCollection } from 'astro:content';
 import { SECTIONS } from '@cv/sections';
-import profile from '../../../content/profile/public.json';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const profile = JSON.parse(
+  fs.readFileSync(
+    fs.existsSync(path.resolve('src/content/profile/full.json'))
+      ? path.resolve('src/content/profile/full.json')
+      : path.resolve('src/content/profile/public.json'),
+    'utf-8'
+  )
+);
 
 const lang = 'en' as const;
 const s = SECTIONS[lang];
@@ -85,6 +95,7 @@ const education = (profile.education as unknown as EduEntry[]) ?? [];
   <p class="subtitle">{profile.title}</p>
   <p class="contact">
     {profile.email}
+    {profile.phone && <span> · {profile.phone}</span>}
     {profile.location && <span> · {profile.location}</span>}
     {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
     {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}

--- a/src/pages/en/cv/index.astro
+++ b/src/pages/en/cv/index.astro
@@ -1,0 +1,131 @@
+---
+import { getCollection } from 'astro:content';
+import { SECTIONS } from '@cv/sections';
+import profile from '../../../content/profile/public.json';
+
+const lang = 'en' as const;
+const s = SECTIONS[lang];
+
+const work = (await getCollection('work-en'))
+  .filter(e => e.data.include?.cv !== false)
+  .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
+
+function formatDate(d: Date): string {
+  return d.toLocaleString('en', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+function fmtRange(entry: (typeof work)[number]): string {
+  const start = formatDate(entry.data.dateStart);
+  const end = typeof entry.data.dateEnd === 'string'
+    ? s.present
+    : formatDate(entry.data.dateEnd as Date);
+  return `${start} – ${end}`;
+}
+
+const cvUpdated = import.meta.env.PUBLIC_CV_UPDATED ?? '';
+const updatedLabel = cvUpdated
+  ? (() => {
+      const d = new Date(cvUpdated + 'T00:00:00Z');
+      return s.updated + ' ' + d.toLocaleString('en', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+    })()
+  : '';
+
+const allTech = [...new Set(work.flatMap(e => e.data.tech ?? []))];
+
+type EduEntry = { institution: string; degree: string; year: string };
+const education = (profile.education as unknown as EduEntry[]);
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <title>{profile.name} — CV</title>
+  <style is:inline>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 10pt;
+      line-height: 1.45;
+      color: #111;
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 18mm 0;
+    }
+    h1 { font-size: 18pt; font-weight: bold; margin-bottom: 2pt; }
+    .subtitle { font-size: 10pt; color: #333; margin-bottom: 4pt; }
+    .contact { font-size: 9pt; color: #333; }
+    .contact a { color: #333; text-decoration: none; }
+    h2 {
+      font-size: 10pt;
+      font-weight: bold;
+      text-transform: uppercase;
+      letter-spacing: 0.5pt;
+      border-bottom: 0.75pt solid #111;
+      padding-bottom: 2pt;
+      margin: 14pt 0 6pt;
+    }
+    .entry { margin-bottom: 9pt; }
+    .entry-header { display: flex; justify-content: space-between; align-items: baseline; }
+    .entry-company { font-weight: bold; font-size: 10pt; }
+    .entry-dates { font-size: 9pt; color: #444; white-space: nowrap; padding-left: 8pt; }
+    .entry-meta { font-size: 9pt; color: #444; margin-bottom: 3pt; }
+    .bullets { margin: 3pt 0 0 14pt; padding: 0; }
+    .bullets li { margin-bottom: 1.5pt; }
+    .skills { font-size: 9pt; line-height: 1.6; }
+    .updated { font-size: 8pt; color: #888; margin-top: 18pt; text-align: right; }
+    @media print {
+      body { padding: 0; max-width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <h1>{profile.name}</h1>
+  <p class="subtitle">{profile.title}</p>
+  <p class="contact">
+    {profile.email}
+    {profile.location && <span> · {profile.location}</span>}
+    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
+    {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}
+  </p>
+
+  <h2>{s.experience}</h2>
+  {work.map(entry => (
+    <div class="entry">
+      <div class="entry-header">
+        <span class="entry-company">{entry.data.company}</span>
+        <span class="entry-dates">{fmtRange(entry)}</span>
+      </div>
+      <div class="entry-meta">
+        {entry.data.role}{entry.data.location ? ` · ${entry.data.location}` : ''}
+      </div>
+      {entry.data.bullets && entry.data.bullets.length > 0 && (
+        <ul class="bullets">
+          {entry.data.bullets.map(b => <li>{b}</li>)}
+        </ul>
+      )}
+    </div>
+  ))}
+
+  {education.length > 0 && (
+    <>
+      <h2>{s.education}</h2>
+      {education.map(edu => (
+        <div class="entry">
+          <div class="entry-header">
+            <span class="entry-company">{edu.institution}</span>
+            <span class="entry-dates">{edu.year}</span>
+          </div>
+          <div class="entry-meta">{edu.degree}</div>
+        </div>
+      ))}
+    </>
+  )}
+
+  <h2>{s.skills}</h2>
+  <p class="skills">{allTech.join(' · ')}</p>
+
+  {updatedLabel && <p class="updated">{updatedLabel}</p>}
+</body>
+</html>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -13,6 +13,7 @@ const blog = (await getCollection("blog-en"))
   .slice(0, SITE.NUM_POSTS_ON_HOMEPAGE);
 
 const work = (await getCollection("work-en"))
+  .filter(e => e.data.include.web)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf())
   .slice(0, SITE.NUM_WORKS_ON_HOMEPAGE);
 

--- a/src/pages/en/work/[...slug].astro
+++ b/src/pages/en/work/[...slug].astro
@@ -6,7 +6,7 @@ import { dateRange, idToSlug } from "@lib/utils";
 import BackToPrev from "@components/BackToPrev.astro";
 
 export async function getStaticPaths() {
-  const work = await getCollection("work-en");
+  const work = (await getCollection("work-en")).filter((entry) => entry.data.include.web);
   return work.map((entry) => ({
     params: { slug: idToSlug(entry.id) },
     props: entry,

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -37,13 +37,29 @@ const updatedLabel = cvUpdated
           <a
             href={`/cv/javier-zapata-en-${cvHash}.pdf`}
             download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
+            title="Download CV as PDF"
+            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="7 10 12 15 17 10"/>
+              <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+            PDF
+          </a>
           <a
             href={`/cv/javier-zapata-en-${cvHash}.docx`}
             download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
+            title="Download CV as Word document"
+            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="7 10 12 15 17 10"/>
+              <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+            DOCX
+          </a>
           {updatedLabel && (
             <span class="text-xs opacity-50">{updatedLabel}</span>
           )}

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -17,6 +17,15 @@ const work = await Promise.all(
 
 const icons = getIconMap(import.meta.glob("/src/assets/work/*/icon.*", { eager: true }) as Record<string, { default: { src: string } }>);
 
+const cvHash = import.meta.env.PUBLIC_CV_HASH ?? 'latest';
+const cvUpdated = import.meta.env.PUBLIC_CV_UPDATED ?? '';
+const updatedLabel = cvUpdated
+  ? (() => {
+      const d = new Date(cvUpdated + 'T00:00:00Z');
+      return 'Updated ' + d.toLocaleString('en', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+    })()
+  : '';
+
 ---
 
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
@@ -53,6 +62,25 @@ const icons = getIconMap(import.meta.glob("/src/assets/work/*/icon.*", { eager: 
           })
         }
       </ul>
+      <div class="animate mt-10 flex flex-col gap-2">
+        <div class="text-sm font-semibold text-black dark:text-white">Download CV</div>
+        <div class="flex items-center gap-4">
+          <a
+            href={`/cv/javier-zapata-en-${cvHash}.pdf`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <a
+            href={`/cv/javier-zapata-en-${cvHash}.docx`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
+          {updatedLabel && (
+            <span class="text-xs opacity-50">{updatedLabel}</span>
+          )}
+        </div>
+      </div>
     </div>
   </Container>
 </PageLayout>
+

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -33,35 +33,27 @@ const updatedLabel = cvUpdated
     <div class="space-y-10">
       <div class="animate flex items-baseline justify-between gap-4">
         <span class="font-semibold text-black dark:text-white">Work</span>
-        <div class="flex items-center gap-4 shrink-0">
+        <div class="flex items-center gap-2 shrink-0">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
           <a
             href={`/cv/javier-zapata-en-${cvHash}.pdf`}
             download
             title="Download CV as PDF"
-            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            PDF
-          </a>
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <span class="text-neutral-300 dark:text-neutral-600" aria-hidden="true">&middot;</span>
           <a
             href={`/cv/javier-zapata-en-${cvHash}.docx`}
             download
             title="Download CV as Word document"
-            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            DOCX
-          </a>
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
           {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
+            <span class="text-xs opacity-50 ml-1">{updatedLabel}</span>
           )}
         </div>
       </div>

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -34,26 +34,32 @@ const updatedLabel = cvUpdated
       <div class="animate flex items-baseline justify-between gap-4">
         <span class="font-semibold text-black dark:text-white">Work</span>
         <div class="flex items-center gap-2 shrink-0">
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-            <polyline points="7 10 12 15 17 10"/>
-            <line x1="12" y1="15" x2="12" y2="3"/>
-          </svg>
           <a
             href={`/cv/javier-zapata-en-${cvHash}.pdf`}
             download
             title="Download CV as PDF"
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
-          <span class="text-neutral-300 dark:text-neutral-600" aria-hidden="true">&middot;</span>
+            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+            </svg>
+            <span class="text-sm">PDF</span>
+          </a>
           <a
             href={`/cv/javier-zapata-en-${cvHash}.docx`}
             download
             title="Download CV as Word document"
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
+            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+            </svg>
+            <span class="text-sm">DOCX</span>
+          </a>
           {updatedLabel && (
-            <span class="text-xs opacity-50 ml-1">{updatedLabel}</span>
+            <span class="text-xs opacity-50">{updatedLabel}</span>
           )}
         </div>
       </div>

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -6,6 +6,7 @@ import { dateRange, getIconMap, idToSlug } from "@lib/utils";
 import { WORK_EN as WORK } from "@consts";
 
 const collection = (await getCollection("work-en"))
+  .filter(e => e.data.include.web)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
 
 const work = await Promise.all(

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -34,6 +34,24 @@ const updatedLabel = cvUpdated
       <div class="animate font-semibold text-black dark:text-white">
         Work
       </div>
+      <div class="animate flex flex-col gap-2">
+        <div class="text-sm font-semibold text-black dark:text-white">Download CV</div>
+        <div class="flex items-center gap-4">
+          <a
+            href={`/cv/javier-zapata-en-${cvHash}.pdf`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <a
+            href={`/cv/javier-zapata-en-${cvHash}.docx`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
+          {updatedLabel && (
+            <span class="text-xs opacity-50">{updatedLabel}</span>
+          )}
+        </div>
+      </div>
       <ul class="flex flex-col space-y-4">
         {
           work.map(entry => {
@@ -62,24 +80,6 @@ const updatedLabel = cvUpdated
           })
         }
       </ul>
-      <div class="animate mt-10 flex flex-col gap-2">
-        <div class="text-sm font-semibold text-black dark:text-white">Download CV</div>
-        <div class="flex items-center gap-4">
-          <a
-            href={`/cv/javier-zapata-en-${cvHash}.pdf`}
-            download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
-          <a
-            href={`/cv/javier-zapata-en-${cvHash}.docx`}
-            download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
-          {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
-          )}
-        </div>
-      </div>
     </div>
   </Container>
 </PageLayout>

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -31,12 +31,9 @@ const updatedLabel = cvUpdated
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
   <Container>
     <div class="space-y-10">
-      <div class="animate font-semibold text-black dark:text-white">
-        Work
-      </div>
-      <div class="animate flex flex-col gap-2">
-        <div class="text-sm font-semibold text-black dark:text-white">Download CV</div>
-        <div class="flex items-center gap-4">
+      <div class="animate flex items-baseline justify-between gap-4">
+        <span class="font-semibold text-black dark:text-white">Work</span>
+        <div class="flex items-center gap-4 shrink-0">
           <a
             href={`/cv/javier-zapata-en-${cvHash}.pdf`}
             download

--- a/src/pages/en/work/index.astro
+++ b/src/pages/en/work/index.astro
@@ -31,37 +31,39 @@ const updatedLabel = cvUpdated
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
   <Container>
     <div class="space-y-10">
-      <div class="animate flex items-baseline justify-between gap-4">
-        <span class="font-semibold text-black dark:text-white">Work</span>
-        <div class="flex items-center gap-2 shrink-0">
-          <a
-            href={`/cv/javier-zapata-en-${cvHash}.pdf`}
-            download
-            title="Download CV as PDF"
-            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
-              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-            </svg>
-            <span class="text-sm">PDF</span>
-          </a>
-          <a
-            href={`/cv/javier-zapata-en-${cvHash}.docx`}
-            download
-            title="Download CV as Word document"
-            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
-              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-            </svg>
-            <span class="text-sm">DOCX</span>
-          </a>
-          {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
-          )}
+      <div class="animate space-y-1">
+        <div class="flex items-center justify-between gap-4">
+          <span class="font-semibold text-black dark:text-white">Work</span>
+          <div class="flex items-center gap-2 shrink-0">
+            <a
+              href={`/cv/javier-zapata-en-${cvHash}.pdf`}
+              download
+              title="Download CV as PDF"
+              class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+                <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+                <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+              </svg>
+              <span class="text-sm">PDF</span>
+            </a>
+            <a
+              href={`/cv/javier-zapata-en-${cvHash}.docx`}
+              download
+              title="Download CV as Word document"
+              class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+                <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+                <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+              </svg>
+              <span class="text-sm">DOCX</span>
+            </a>
+          </div>
         </div>
+        {updatedLabel && (
+          <p class="text-xs opacity-50">{updatedLabel}</p>
+        )}
       </div>
       <ul class="flex flex-col space-y-4">
         {

--- a/src/pages/es/cv/index.astro
+++ b/src/pages/es/cv/index.astro
@@ -1,7 +1,17 @@
 ---
 import { getCollection } from 'astro:content';
 import { SECTIONS } from '@cv/sections';
-import profile from '../../../content/profile/public.json';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const profile = JSON.parse(
+  fs.readFileSync(
+    fs.existsSync(path.resolve('src/content/profile/full.json'))
+      ? path.resolve('src/content/profile/full.json')
+      : path.resolve('src/content/profile/public.json'),
+    'utf-8'
+  )
+);
 
 const lang = 'es' as const;
 const s = SECTIONS[lang];
@@ -87,6 +97,7 @@ const education = (profile.education as unknown as EduEntry[]) ?? [];
   <p class="subtitle">{profile.title}</p>
   <p class="contact">
     {profile.email}
+    {profile.phone && <span> · {profile.phone}</span>}
     {locationEs && <span> · {locationEs}</span>}
     {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
     {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}

--- a/src/pages/es/cv/index.astro
+++ b/src/pages/es/cv/index.astro
@@ -7,7 +7,7 @@ const lang = 'es' as const;
 const s = SECTIONS[lang];
 
 const work = (await getCollection('work-es'))
-  .filter(e => e.data.include?.cv !== false)
+  .filter(e => e.data.include.cv)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
 
 function formatDate(d: Date): string {
@@ -32,10 +32,10 @@ const updatedLabel = cvUpdated
   : '';
 
 const allTech = [...new Set(work.flatMap(e => e.data.tech ?? []))];
-const locationEs = profile.location.replace('Spain', 'España');
+const locationEs = profile.location ? profile.location.replace('Spain', 'España') : '';
 
 type EduEntry = { institution: string; degree: string; year: string };
-const education = (profile.education as unknown as EduEntry[]);
+const education = (profile.education as unknown as EduEntry[]) ?? [];
 ---
 <!DOCTYPE html>
 <html lang="es">

--- a/src/pages/es/cv/index.astro
+++ b/src/pages/es/cv/index.astro
@@ -37,7 +37,7 @@ const updatedLabel = cvUpdated
   ? (() => {
       const d = new Date(cvUpdated + 'T00:00:00Z');
       const month = d.toLocaleString('es', { month: 'long', timeZone: 'UTC' });
-      return s.updated + ' ' + month + ' de ' + d.getUTCFullYear();
+      return s.updated + ' en ' + month + ' de ' + d.getUTCFullYear();
     })()
   : '';
 

--- a/src/pages/es/cv/index.astro
+++ b/src/pages/es/cv/index.astro
@@ -1,0 +1,133 @@
+---
+import { getCollection } from 'astro:content';
+import { SECTIONS } from '@cv/sections';
+import profile from '../../../content/profile/public.json';
+
+const lang = 'es' as const;
+const s = SECTIONS[lang];
+
+const work = (await getCollection('work-es'))
+  .filter(e => e.data.include?.cv !== false)
+  .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
+
+function formatDate(d: Date): string {
+  return d.toLocaleString('es', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+function fmtRange(entry: (typeof work)[number]): string {
+  const start = formatDate(entry.data.dateStart);
+  const end = typeof entry.data.dateEnd === 'string'
+    ? s.present
+    : formatDate(entry.data.dateEnd as Date);
+  return `${start} – ${end}`;
+}
+
+const cvUpdated = import.meta.env.PUBLIC_CV_UPDATED ?? '';
+const updatedLabel = cvUpdated
+  ? (() => {
+      const d = new Date(cvUpdated + 'T00:00:00Z');
+      const month = d.toLocaleString('es', { month: 'long', timeZone: 'UTC' });
+      return s.updated + ' ' + month + ' de ' + d.getUTCFullYear();
+    })()
+  : '';
+
+const allTech = [...new Set(work.flatMap(e => e.data.tech ?? []))];
+const locationEs = profile.location.replace('Spain', 'España');
+
+type EduEntry = { institution: string; degree: string; year: string };
+const education = (profile.education as unknown as EduEntry[]);
+---
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <title>{profile.name} — CV</title>
+  <style is:inline>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 10pt;
+      line-height: 1.45;
+      color: #111;
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 18mm 0;
+    }
+    h1 { font-size: 18pt; font-weight: bold; margin-bottom: 2pt; }
+    .subtitle { font-size: 10pt; color: #333; margin-bottom: 4pt; }
+    .contact { font-size: 9pt; color: #333; }
+    .contact a { color: #333; text-decoration: none; }
+    h2 {
+      font-size: 10pt;
+      font-weight: bold;
+      text-transform: uppercase;
+      letter-spacing: 0.5pt;
+      border-bottom: 0.75pt solid #111;
+      padding-bottom: 2pt;
+      margin: 14pt 0 6pt;
+    }
+    .entry { margin-bottom: 9pt; }
+    .entry-header { display: flex; justify-content: space-between; align-items: baseline; }
+    .entry-company { font-weight: bold; font-size: 10pt; }
+    .entry-dates { font-size: 9pt; color: #444; white-space: nowrap; padding-left: 8pt; }
+    .entry-meta { font-size: 9pt; color: #444; margin-bottom: 3pt; }
+    .bullets { margin: 3pt 0 0 14pt; padding: 0; }
+    .bullets li { margin-bottom: 1.5pt; }
+    .skills { font-size: 9pt; line-height: 1.6; }
+    .updated { font-size: 8pt; color: #888; margin-top: 18pt; text-align: right; }
+    @media print {
+      body { padding: 0; max-width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <h1>{profile.name}</h1>
+  <p class="subtitle">{profile.title}</p>
+  <p class="contact">
+    {profile.email}
+    {locationEs && <span> · {locationEs}</span>}
+    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
+    {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}
+  </p>
+
+  <h2>{s.experience}</h2>
+  {work.map(entry => (
+    <div class="entry">
+      <div class="entry-header">
+        <span class="entry-company">{entry.data.company}</span>
+        <span class="entry-dates">{fmtRange(entry)}</span>
+      </div>
+      <div class="entry-meta">
+        {entry.data.role}{entry.data.location ? ` · ${entry.data.location}` : ''}
+      </div>
+      {entry.data.bullets && entry.data.bullets.length > 0 && (
+        <ul class="bullets">
+          {entry.data.bullets.map(b => <li>{b}</li>)}
+        </ul>
+      )}
+    </div>
+  ))}
+
+  {education.length > 0 && (
+    <>
+      <h2>{s.education}</h2>
+      {education.map(edu => (
+        <div class="entry">
+          <div class="entry-header">
+            <span class="entry-company">{edu.institution}</span>
+            <span class="entry-dates">{edu.year}</span>
+          </div>
+          <div class="entry-meta">{edu.degree}</div>
+        </div>
+      ))}
+    </>
+  )}
+
+  <h2>{s.skills}</h2>
+  <p class="skills">{allTech.join(' · ')}</p>
+
+  {updatedLabel && <p class="updated">{updatedLabel}</p>}
+</body>
+</html>

--- a/src/pages/es/cv/index.astro
+++ b/src/pages/es/cv/index.astro
@@ -99,8 +99,8 @@ const education = (profile.education as unknown as EduEntry[]) ?? [];
     {profile.email}
     {profile.phone && <span> · {profile.phone}</span>}
     {locationEs && <span> · {locationEs}</span>}
-    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace('https://', '')}</a></span>}
-    {profile.github && <span> · <a href={profile.github}>{profile.github.replace('https://', '')}</a></span>}
+    {profile.linkedin && <span> · <a href={profile.linkedin}>{profile.linkedin.replace(/^https?:\/\/(www\.)?/, '')}</a></span>}
+    {profile.github && <span> · <a href={profile.github}>{profile.github.replace(/^https?:\/\/(www\.)?/, '')}</a></span>}
   </p>
 
   <h2>{s.experience}</h2>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -13,6 +13,7 @@ const blog = (await getCollection("blog-es"))
   .slice(0, SITE.NUM_POSTS_ON_HOMEPAGE);
 
 const work = (await getCollection("work-es"))
+  .filter(e => e.data.include.web)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf())
   .slice(0, SITE.NUM_WORKS_ON_HOMEPAGE);
 

--- a/src/pages/es/work/[...slug].astro
+++ b/src/pages/es/work/[...slug].astro
@@ -6,7 +6,7 @@ import { dateRange, idToSlug } from "@lib/utils";
 import BackToPrev from "@components/BackToPrev.astro";
 
 export async function getStaticPaths() {
-  const work = await getCollection("work-es");
+  const work = (await getCollection("work-es")).filter((entry) => entry.data.include.web);
   return work.map((entry) => ({
     params: { slug: idToSlug(entry.id) },
     props: entry,

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -35,26 +35,32 @@ const updatedLabel = cvUpdated
       <div class="animate flex items-baseline justify-between gap-4">
         <span class="font-semibold text-black dark:text-white">Experiencia</span>
         <div class="flex items-center gap-2 shrink-0">
-          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-            <polyline points="7 10 12 15 17 10"/>
-            <line x1="12" y1="15" x2="12" y2="3"/>
-          </svg>
           <a
             href={`/cv/javier-zapata-es-${cvHash}.pdf`}
             download
             title="Descargar CV en PDF"
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
-          <span class="text-neutral-300 dark:text-neutral-600" aria-hidden="true">&middot;</span>
+            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+            </svg>
+            <span class="text-sm">PDF</span>
+          </a>
           <a
             href={`/cv/javier-zapata-es-${cvHash}.docx`}
             download
             title="Descargar CV en Word"
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
+            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+            </svg>
+            <span class="text-sm">DOCX</span>
+          </a>
           {updatedLabel && (
-            <span class="text-xs opacity-50 ml-1">{updatedLabel}</span>
+            <span class="text-xs opacity-50">{updatedLabel}</span>
           )}
         </div>
       </div>

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -32,12 +32,9 @@ const updatedLabel = cvUpdated
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
   <Container>
     <div class="space-y-10">
-      <div class="animate font-semibold text-black dark:text-white">
-        Experiencia
-      </div>
-      <div class="animate flex flex-col gap-2">
-        <div class="text-sm font-semibold text-black dark:text-white">Descargar CV</div>
-        <div class="flex items-center gap-4">
+      <div class="animate flex items-baseline justify-between gap-4">
+        <span class="font-semibold text-black dark:text-white">Experiencia</span>
+        <div class="flex items-center gap-4 shrink-0">
           <a
             href={`/cv/javier-zapata-es-${cvHash}.pdf`}
             download

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -38,13 +38,29 @@ const updatedLabel = cvUpdated
           <a
             href={`/cv/javier-zapata-es-${cvHash}.pdf`}
             download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
+            title="Descargar CV en PDF"
+            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="7 10 12 15 17 10"/>
+              <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+            PDF
+          </a>
           <a
             href={`/cv/javier-zapata-es-${cvHash}.docx`}
             download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
+            title="Descargar CV en Word"
+            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="7 10 12 15 17 10"/>
+              <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+            DOCX
+          </a>
           {updatedLabel && (
             <span class="text-xs opacity-50">{updatedLabel}</span>
           )}

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -34,35 +34,27 @@ const updatedLabel = cvUpdated
     <div class="space-y-10">
       <div class="animate flex items-baseline justify-between gap-4">
         <span class="font-semibold text-black dark:text-white">Experiencia</span>
-        <div class="flex items-center gap-4 shrink-0">
+        <div class="flex items-center gap-2 shrink-0">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
           <a
             href={`/cv/javier-zapata-es-${cvHash}.pdf`}
             download
             title="Descargar CV en PDF"
-            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            PDF
-          </a>
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <span class="text-neutral-300 dark:text-neutral-600" aria-hidden="true">&middot;</span>
           <a
             href={`/cv/javier-zapata-es-${cvHash}.docx`}
             download
             title="Descargar CV en Word"
-            class="flex items-center gap-1 text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            DOCX
-          </a>
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
           {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
+            <span class="text-xs opacity-50 ml-1">{updatedLabel}</span>
           )}
         </div>
       </div>

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -17,6 +17,16 @@ const work = await Promise.all(
 
 const icons = getIconMap(import.meta.glob("/src/assets/work/*/icon.*", { eager: true }) as Record<string, { default: { src: string } }>);
 
+const cvHash = import.meta.env.PUBLIC_CV_HASH ?? 'latest';
+const cvUpdated = import.meta.env.PUBLIC_CV_UPDATED ?? '';
+const updatedLabel = cvUpdated
+  ? (() => {
+      const d = new Date(cvUpdated + 'T00:00:00Z');
+      const month = d.toLocaleString('es', { month: 'long', timeZone: 'UTC' });
+      return 'Actualizado ' + month + ' de ' + d.getUTCFullYear();
+    })()
+  : '';
+
 ---
 
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
@@ -53,6 +63,25 @@ const icons = getIconMap(import.meta.glob("/src/assets/work/*/icon.*", { eager: 
           })
         }
       </ul>
+      <div class="animate mt-10 flex flex-col gap-2">
+        <div class="text-sm font-semibold text-black dark:text-white">Descargar CV</div>
+        <div class="flex items-center gap-4">
+          <a
+            href={`/cv/javier-zapata-es-${cvHash}.pdf`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <a
+            href={`/cv/javier-zapata-es-${cvHash}.docx`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
+          {updatedLabel && (
+            <span class="text-xs opacity-50">{updatedLabel}</span>
+          )}
+        </div>
+      </div>
     </div>
   </Container>
 </PageLayout>
+

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -24,7 +24,7 @@ const updatedLabel = cvUpdated
   ? (() => {
       const d = new Date(cvUpdated + 'T00:00:00Z');
       const month = d.toLocaleString('es', { month: 'long', timeZone: 'UTC' });
-      return 'Actualizado ' + month + ' de ' + d.getUTCFullYear();
+      return 'Actualizado en ' + month + ' de ' + d.getUTCFullYear();
     })()
   : '';
 

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -32,37 +32,39 @@ const updatedLabel = cvUpdated
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
   <Container>
     <div class="space-y-10">
-      <div class="animate flex items-baseline justify-between gap-4">
-        <span class="font-semibold text-black dark:text-white">Experiencia</span>
-        <div class="flex items-center gap-2 shrink-0">
-          <a
-            href={`/cv/javier-zapata-es-${cvHash}.pdf`}
-            download
-            title="Descargar CV en PDF"
-            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
-              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-            </svg>
-            <span class="text-sm">PDF</span>
-          </a>
-          <a
-            href={`/cv/javier-zapata-es-${cvHash}.docx`}
-            download
-            title="Descargar CV en Word"
-            class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
-              <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
-              <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
-            </svg>
-            <span class="text-sm">DOCX</span>
-          </a>
-          {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
-          )}
+      <div class="animate space-y-1">
+        <div class="flex items-center justify-between gap-4">
+          <span class="font-semibold text-black dark:text-white">Experiencia</span>
+          <div class="flex items-center gap-2 shrink-0">
+            <a
+              href={`/cv/javier-zapata-es-${cvHash}.pdf`}
+              download
+              title="Descargar CV en PDF"
+              class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+                <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+                <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+              </svg>
+              <span class="text-sm">PDF</span>
+            </a>
+            <a
+              href={`/cv/javier-zapata-es-${cvHash}.docx`}
+              download
+              title="Descargar CV en Word"
+              class="relative group w-fit flex pl-8 pr-3 py-1.5 flex-nowrap rounded border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors duration-300 ease-in-out"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="absolute top-1/2 left-2 -translate-y-1/2 size-4 stroke-2 fill-none stroke-current -rotate-90">
+                <line x1="5" y1="12" x2="19" y2="12" class="translate-x-2 group-hover:translate-x-0 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-in-out" />
+                <polyline points="12 5 5 12 12 19" class="translate-x-1 group-hover:translate-x-0 transition-transform duration-300 ease-in-out" />
+              </svg>
+              <span class="text-sm">DOCX</span>
+            </a>
+          </div>
         </div>
+        {updatedLabel && (
+          <p class="text-xs opacity-50">{updatedLabel}</p>
+        )}
       </div>
       <ul class="flex flex-col space-y-4">
         {

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -35,6 +35,24 @@ const updatedLabel = cvUpdated
       <div class="animate font-semibold text-black dark:text-white">
         Experiencia
       </div>
+      <div class="animate flex flex-col gap-2">
+        <div class="text-sm font-semibold text-black dark:text-white">Descargar CV</div>
+        <div class="flex items-center gap-4">
+          <a
+            href={`/cv/javier-zapata-es-${cvHash}.pdf`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >PDF</a>
+          <a
+            href={`/cv/javier-zapata-es-${cvHash}.docx`}
+            download
+            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
+          >DOCX</a>
+          {updatedLabel && (
+            <span class="text-xs opacity-50">{updatedLabel}</span>
+          )}
+        </div>
+      </div>
       <ul class="flex flex-col space-y-4">
         {
           work.map(entry => {
@@ -63,24 +81,6 @@ const updatedLabel = cvUpdated
           })
         }
       </ul>
-      <div class="animate mt-10 flex flex-col gap-2">
-        <div class="text-sm font-semibold text-black dark:text-white">Descargar CV</div>
-        <div class="flex items-center gap-4">
-          <a
-            href={`/cv/javier-zapata-es-${cvHash}.pdf`}
-            download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >PDF</a>
-          <a
-            href={`/cv/javier-zapata-es-${cvHash}.docx`}
-            download
-            class="text-sm underline underline-offset-4 decoration-dashed hover:opacity-60 transition-opacity"
-          >DOCX</a>
-          {updatedLabel && (
-            <span class="text-xs opacity-50">{updatedLabel}</span>
-          )}
-        </div>
-      </div>
     </div>
   </Container>
 </PageLayout>

--- a/src/pages/es/work/index.astro
+++ b/src/pages/es/work/index.astro
@@ -6,6 +6,7 @@ import { dateRange, getIconMap, idToSlug } from "@lib/utils";
 import { WORK_ES as WORK } from "@consts";
 
 const collection = (await getCollection("work-es"))
+  .filter(e => e.data.include.web)
   .sort((a, b) => b.data.dateStart.valueOf() - a.data.dateStart.valueOf());
 
 const work = await Promise.all(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
       "@styles/*": ["./src/styles/*"],
       "@assets/*": ["./src/assets/*"],
       "@consts": ["./src/consts.ts"],
-      "@types": ["./src/types.ts"]
+      "@types": ["./src/types.ts"],
+      "@cv/*": ["./src/cv/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Makes javi.io the single source of truth for the career timeline, generating downloadable ATS-optimised PDF and DOCX CVs in English and Spanish, always in sync with the website.

## What's in this PR

- **Task 0** — Extended `work-en` / `work-es` schema with `bullets`, `tech`, `location`, `include` fields; added `src/content/profile/public.json`
- **Task 1** — New `/en/cv` and `/es/cv` pages: single-column ATS layout, inline CSS (required for `file://` PDF generation), `noindex`
- **Task 2** — `scripts/cv-meta.mjs`: content hash + last-updated date injected at build time via `vite.define`
- **Task 3** — `scripts/generate-pdf.mjs`: Playwright prints both CV pages to A4 PDF via `file://`
- **Task 4** — `scripts/generate-docx.mjs`: `docx` + `gray-matter` generate Word documents from the same source data
- **Task 5** — Download buttons on `/en/work` and `/es/work`: pill-style, matching the BackToTop component, with last-updated date below the section title
- **Task 6** — CI workflow updated: `fetch-depth: 0`, Playwright browser cache, generate step runs after build and before deploy

## Files generated in CI

```
dist/cv/javier-zapata-en-{hash}.pdf
dist/cv/javier-zapata-es-{hash}.pdf
dist/cv/javier-zapata-en-{hash}.docx
dist/cv/javier-zapata-es-{hash}.docx
```

The hash is derived from the work file contents, so filenames are stable between deploys when data hasn't changed. The download links on `/work` reference the same hash at build time.

## Notes

- `src/content/profile/full.json` (with phone) is gitignored and never committed — run `generate:cv` locally after adding it for a private version
- `public/cv/` is also gitignored; the generate scripts write there so `pnpm dev` can serve the files