### PR TITLE
refactor: consolidate all date formats to YYYY-MM-DD

### DIFF
--- a/scripts/generate-docx.mjs
+++ b/scripts/generate-docx.mjs
@@ -77,18 +77,13 @@ function parseWorkFiles(dir) {
 }
 
 function parseDate(dateVal) {
-  if (dateVal instanceof Date) {
-    return dateVal;
-  }
+  if (dateVal instanceof Date) return dateVal;
   const dateStr = String(dateVal || "");
-  const [m, d, y] = dateStr.split("/").map(Number);
-  const date = new Date(Date.UTC(y, m - 1, d));
-  if (isNaN(date.getTime())) {
-    throw new Error(
-      `Invalid date format: "${dateStr}". Expected MM/DD/YYYY`,
-    );
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid date: "${dateStr}". Expected YYYY-MM-DD`);
   }
-  return date;
+  return d;
 }
 
 function formatDate(dateStr, locale) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,24 +2,6 @@ import { file, glob } from "astro/loaders";
 import { defineCollection, type SchemaContext } from "astro:content";
 import { z } from "zod";
 
-const parseWorkDate = (val: string): Date => {
-  const [m, d, y] = val.split("/").map(Number);
-  if (isNaN(m) || isNaN(d) || isNaN(y) || m < 1 || m > 12 || d < 1 || d > 31) {
-    throw new Error(`Invalid date values in: "${val}". Expected MM/DD/YYYY`);
-  }
-  const date = new Date(Date.UTC(y, m - 1, d));
-  if (
-    isNaN(date.getTime()) ||
-    date.getUTCMonth() !== m - 1 ||
-    date.getUTCDate() !== d
-  ) {
-    throw new Error(
-      `Invalid date format or value: "${val}". Expected MM/DD/YYYY`,
-    );
-  }
-  return date;
-};
-
 const blogSchema = ({ image }: SchemaContext) =>
   z.object({
     title: z.string(),
@@ -42,14 +24,11 @@ const blogEn = defineCollection({
 const workSchema = z.object({
   company: z.string(),
   role: z.string(),
-  dateStart: z.string().transform(parseWorkDate),
-  dateEnd: z
-    .string()
-    .transform((val) =>
-      ["current", "actualidad"].includes(val.trim().toLowerCase())
-        ? val
-        : parseWorkDate(val),
-    ),
+  dateStart: z.coerce.date(),
+  dateEnd: z.union([
+    z.string().refine(s => ["current", "actualidad"].includes(s.trim().toLowerCase())),
+    z.coerce.date(),
+  ]),
   location: z.string().optional(),
   bullets: z.array(z.string()).optional(),
   tech: z.array(z.string()).optional(),

--- a/src/content/projects-en/adria-en-casa/index.md
+++ b/src/content/projects-en/adria-en-casa/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Adrià en casa"
 description: "Mobile cooking application for Telefónica, developed in collaboration with world-renowned chef Ferran Adrià."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "adria-en-casa"
 hero: ../../../assets/projects/adria-en-casa/hero.jpg

--- a/src/content/projects-en/agents/index.md
+++ b/src/content/projects-en/agents/index.md
@@ -1,7 +1,7 @@
 ---
 title: "agents"
 description: "Agentic skills for professional developer workflows — structured 1:1s, git-aware reviews, and action tracking. Works with Claude Code, Cursor, Codex, and more."
-date: "May 30 2026"
+date: 2026-05-30
 type: "personal"
 repoURL: "https://github.com/jzfgo/agents"
 demoURL: "https://www.skills.sh/jzfgo/agents"

--- a/src/content/projects-en/aramon-snow-go/index.md
+++ b/src/content/projects-en/aramon-snow-go/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Aramón Snow & Go"
 description: "Mobile companion app for Aramón ski resorts developed for Movistar, providing resort information and navigation for skiers across multiple platforms."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "aramon-snow-go"
 hero: ../../../assets/projects/aramon-snow-go/hero.jpg

--- a/src/content/projects-en/atopechavalote/index.md
+++ b/src/content/projects-en/atopechavalote/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Atopechavalote!"
 description: "Social networking platform that pioneered online community building around Madrid's nightlife scene, reaching 25,000 registered users."
-date: "Jan 01 2007"
+date: 2007-01-01
 type: "professional"
 translationKey: "atopechavalote"
 hero: ../../../assets/projects/atopechavalote/hero.jpg

--- a/src/content/projects-en/bahiazul-email-marketing/index.md
+++ b/src/content/projects-en/bahiazul-email-marketing/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Email Marketing"
 description: "Series of targeted email marketing campaigns to drive post-pandemic bookings for Bahiazul Resort, using segmentation, A/B testing, and automation."
-date: "Jan 01 2020"
+date: 2020-01-01
 type: "professional"
 translationKey: "bahiazul-email-marketing"
 ---

--- a/src/content/projects-en/bahiazul-kiosk/index.md
+++ b/src/content/projects-en/bahiazul-kiosk/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Digital Kiosk"
 description: "Mobile-first web kiosk for Bahiazul Resort allowing guests to access brochures and resort materials by scanning QR codes."
-date: "Jan 01 2020"
+date: 2020-01-01
 type: "professional"
 translationKey: "bahiazul-kiosk"
 demoURL: "https://dk.bahiazul.com/"

--- a/src/content/projects-en/bahiazul-pms/index.md
+++ b/src/content/projects-en/bahiazul-pms/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul PMS"
 description: "Custom Property Management System for Bahiazul Resort, centralizing reservations, guest management, and internal operations."
-date: "Jan 01 2015"
+date: 2015-01-01
 type: "professional"
 translationKey: "bahiazul-pms"
 hero: ../../../assets/projects/bahiazul-pms/hero.png

--- a/src/content/projects-en/bahiazul-website-v1/index.md
+++ b/src/content/projects-en/bahiazul-website-v1/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Website (v1)"
 description: "First version of Bahiazul Resort's website — a full-stack PHP platform with custom UI design built as the company's primary online presence and booking platform."
-date: "Jan 01 2014"
+date: 2014-01-01
 type: "professional"
 translationKey: "bahiazul-website-v1"
 hero: ../../../assets/projects/bahiazul-website-v1/hero.jpg

--- a/src/content/projects-en/bahiazul-website/index.md
+++ b/src/content/projects-en/bahiazul-website/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Website"
 description: "Next.js and TypeScript redesign of the resort's main website featuring rich media elements and a personalized booking experience."
-date: "Dec 01 2020"
+date: 2020-12-01
 type: "professional"
 translationKey: "bahiazul-website"
 ---

--- a/src/content/projects-en/carroquesi/index.md
+++ b/src/content/projects-en/carroquesi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "carroquesi"
 description: "Collaborative grocery shopping list with shared lists, purchase history, AI-powered receipt scanning, barcode lookup, and per-item price tracking."
-date: "Mar 26 2026"
+date: 2026-03-26
 type: "personal"
 repoURL: "https://github.com/jzfgo/carroquesi"
 demoURL: "https://carroquesi.web.app/"

--- a/src/content/projects-en/english-monstruo/index.md
+++ b/src/content/projects-en/english-monstruo/index.md
@@ -1,7 +1,7 @@
 ---
 title: "English Monstruo"
 description: "Brain Trainer-style mobile game to teach English learners the most common mistakes in the First Certificate Exam (FCE)."
-date: "Mar 01 2013"
+date: 2013-03-01
 type: "professional"
 translationKey: "english-monstruo"
 hero: ../../../assets/projects/english-monstruo/hero.jpg

--- a/src/content/projects-en/fly-fut-ligas/index.md
+++ b/src/content/projects-en/fly-fut-ligas/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fly-Fut Ligas"
 description: "Consumer football platform with AI-assisted video production and mobile application."
-date: "Oct 01 2021"
+date: 2021-10-01
 type: "professional"
 translationKey: "fly-fut-ligas"
 hero: ../../../assets/projects/fly-fut-ligas/hero.png

--- a/src/content/projects-en/fly-fut-pro/index.md
+++ b/src/content/projects-en/fly-fut-pro/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fly-Fut Pro"
 description: "Professional football analysis system with autonomous drone controls and tactical video analysis."
-date: "Jun 01 2022"
+date: 2022-06-01
 type: "professional"
 translationKey: "fly-fut-pro"
 hero: ../../../assets/projects/fly-fut-pro/hero.png

--- a/src/content/projects-en/fuera-de-juego/index.md
+++ b/src/content/projects-en/fuera-de-juego/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fuera de Juego"
 description: "Mobile-first single page app allowing users to predict football matches and win promotional prizes."
-date: "Aug 01 2017"
+date: 2017-08-01
 type: "professional"
 translationKey: "fuera-de-juego"
 hero: ../../../assets/projects/fuera-de-juego/hero.jpg

--- a/src/content/projects-en/minerales-de-la-liga/index.md
+++ b/src/content/projects-en/minerales-de-la-liga/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Minerales de LaLiga"
 description: "Interactive 3D data art experience for Solán de Cabras × LaLiga — parametric crystal generation, Three.js visualization, and video pipeline."
-date: "Jun 01 2024"
+date: 2024-06-01
 type: "professional"
 translationKey: "minerales-de-la-liga"
 ---

--- a/src/content/projects-en/movistar-bike-go/index.md
+++ b/src/content/projects-en/movistar-bike-go/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Movistar Bike & Go"
 description: "Mobile cycling companion app for Movistar, providing route navigation and activity tracking for cyclists."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "movistar-bike-go"
 hero: ../../../assets/projects/movistar-bike-go/hero.jpg

--- a/src/content/projects-en/porcelanosa-ecommerce/index.md
+++ b/src/content/projects-en/porcelanosa-ecommerce/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Porcelanosa Ecommerce"
 description: "Migration of a global Magento Ecommerce to a headless architecture on Adobe Commerce Cloud with Next.js and Payload CMS."
-date: "Jul 01 2025"
+date: 2025-07-01
 type: "professional"
 translationKey: "porcelanosa-ecommerce"
 demoURL: "https://store.porcelanosa.com/"

--- a/src/content/projects-en/quadrant-travel-cloud/index.md
+++ b/src/content/projects-en/quadrant-travel-cloud/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Quadrant Travel Cloud"
 description: "Corporate travel management platform simplifying booking, expense management, and policy compliance."
-date: "Mar 01 2023"
+date: 2023-03-01
 type: "professional"
 translationKey: "quadrant-travel-cloud"
 ---

--- a/src/content/projects-en/sony-pictures-spain/index.md
+++ b/src/content/projects-en/sony-pictures-spain/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Sony Pictures Spain"
 description: "Official Spanish website for Sony Pictures Entertainment — infrastructure migration from GCP to AWS, and ongoing maintenance and feature delivery."
-date: "Jan 01 2023"
+date: 2023-01-01
 type: "professional"
 translationKey: "sony-pictures-spain"
 demoURL: "https://sonypictures.es/"

--- a/src/content/projects-en/telefonica-sdie-2017/index.md
+++ b/src/content/projects-en/telefonica-sdie-2017/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Telefónica SDiE 2017"
 description: "Interactive data visualization single-page application for Fundación Telefónica's annual digital society report."
-date: "Jan 01 2017"
+date: 2017-01-01
 type: "professional"
 translationKey: "telefonica-sdie-2017"
 hero: ../../../assets/projects/telefonica-sdie-2017/hero.png

--- a/src/content/projects-en/un-mundo-aparte/index.md
+++ b/src/content/projects-en/un-mundo-aparte/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Un Mundo Aparte"
 description: "Mobile application for Las Colinas Golf & Country Club, serving as a digital companion for resort guests."
-date: "Jan 01 2018"
+date: 2018-01-01
 type: "professional"
 translationKey: "un-mundo-aparte"
 hero: ../../../assets/projects/un-mundo-aparte/hero.jpg

--- a/src/content/projects-en/voltexa/index.md
+++ b/src/content/projects-en/voltexa/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Voltexa"
 description: "MVP for a renewable energy startup — customer portal, admin panel, branding, landing page, and signup flow built with a lean team of five."
-date: "Jan 01 2023"
+date: 2023-01-01
 type: "professional"
 translationKey: "voltexa"
 hero: ../../../assets/projects/voltexa/hero.webp

--- a/src/content/projects-es/adria-en-casa/index.md
+++ b/src/content/projects-es/adria-en-casa/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Adrià en casa"
 description: "Aplicación móvil de cocina para Telefónica, desarrollada en colaboración con el chef de fama mundial Ferran Adrià."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "adria-en-casa"
 hero: ../../../assets/projects/adria-en-casa/hero.jpg

--- a/src/content/projects-es/agents/index.md
+++ b/src/content/projects-es/agents/index.md
@@ -1,7 +1,7 @@
 ---
 title: "agents"
 description: "Skills agénticas para flujos de trabajo de desarrollo profesional — 1:1s estructurados, revisiones con contexto de git y seguimiento de acciones. Compatible con Claude Code, Cursor, Codex y más."
-date: "May 30 2026"
+date: 2026-05-30
 type: "personal"
 repoURL: "https://github.com/jzfgo/agents"
 demoURL: "https://www.skills.sh/jzfgo/agents"

--- a/src/content/projects-es/aramon-snow-go/index.md
+++ b/src/content/projects-es/aramon-snow-go/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Aramón Snow & Go"
 description: "Aplicación móvil para las estaciones de esquí de Aramón, desarrollada para Movistar, que ofrece información del resort y navegación para esquiadores en múltiples plataformas."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "aramon-snow-go"
 hero: ../../../assets/projects/aramon-snow-go/hero.jpg

--- a/src/content/projects-es/atopechavalote/index.md
+++ b/src/content/projects-es/atopechavalote/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Atopechavalote!"
 description: "Plataforma de red social pionera en la construcción de comunidades online en torno al ocio nocturno de Madrid, que alcanzó 25.000 usuarios registrados."
-date: "Jan 01 2007"
+date: 2007-01-01
 type: "professional"
 translationKey: "atopechavalote"
 hero: ../../../assets/projects/atopechavalote/hero.jpg

--- a/src/content/projects-es/bahiazul-email-marketing/index.md
+++ b/src/content/projects-es/bahiazul-email-marketing/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Email Marketing Bahiazul"
 description: "Serie de campañas de email marketing segmentadas para impulsar las reservas post-pandemia de Bahiazul Resort, usando segmentación, A/B testing y automatización."
-date: "Jan 01 2020"
+date: 2020-01-01
 type: "professional"
 translationKey: "bahiazul-email-marketing"
 ---

--- a/src/content/projects-es/bahiazul-kiosk/index.md
+++ b/src/content/projects-es/bahiazul-kiosk/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Quiosco Digital Bahiazul"
 description: "Quiosco web mobile-first para Bahiazul Resort que permite a los huéspedes acceder a folletos y materiales del resort escaneando códigos QR."
-date: "Jan 01 2020"
+date: 2020-01-01
 type: "professional"
 translationKey: "bahiazul-kiosk"
 demoURL: "https://dk.bahiazul.com/"

--- a/src/content/projects-es/bahiazul-pms/index.md
+++ b/src/content/projects-es/bahiazul-pms/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul PMS"
 description: "Sistema de gestión hotelera (PMS) desarrollado a medida para Bahiazul Resort, que centraliza reservas, gestión de huéspedes y operaciones internas."
-date: "Jan 01 2015"
+date: 2015-01-01
 type: "professional"
 translationKey: "bahiazul-pms"
 hero: ../../../assets/projects/bahiazul-pms/hero.png

--- a/src/content/projects-es/bahiazul-website-v1/index.md
+++ b/src/content/projects-es/bahiazul-website-v1/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Website (v1)"
 description: "Primera versión del sitio web de Bahiazul Resort — una plataforma PHP full-stack con diseño UI personalizado, construida como presencia digital principal y plataforma de reservas."
-date: "Jan 01 2014"
+date: 2014-01-01
 type: "professional"
 translationKey: "bahiazul-website-v1"
 hero: ../../../assets/projects/bahiazul-website-v1/hero.jpg

--- a/src/content/projects-es/bahiazul-website/index.md
+++ b/src/content/projects-es/bahiazul-website/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Bahiazul Website"
 description: "Rediseño en Next.js y TypeScript de la web principal del resort, con elementos multimedia enriquecidos y una experiencia de reserva personalizada."
-date: "Dec 01 2020"
+date: 2020-12-01
 type: "professional"
 translationKey: "bahiazul-website"
 ---

--- a/src/content/projects-es/carroquesi/index.md
+++ b/src/content/projects-es/carroquesi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "carroquesi"
 description: "Lista de la compra colaborativa con listas compartidas, historial de compras, escaneado de tickets con IA, búsqueda por código de barras y seguimiento de precios por producto."
-date: "Mar 26 2026"
+date: 2026-03-26
 type: "personal"
 repoURL: "https://github.com/jzfgo/carroquesi"
 demoURL: "https://carroquesi.web.app/"

--- a/src/content/projects-es/english-monstruo/index.md
+++ b/src/content/projects-es/english-monstruo/index.md
@@ -1,7 +1,7 @@
 ---
 title: "English Monstruo"
 description: "Juego móvil tipo Brain Trainer para enseñar a estudiantes de inglés los errores más comunes del First Certificate Exam (FCE)."
-date: "Mar 01 2013"
+date: 2013-03-01
 type: "professional"
 translationKey: "english-monstruo"
 hero: ../../../assets/projects/english-monstruo/hero.jpg

--- a/src/content/projects-es/fly-fut-ligas/index.md
+++ b/src/content/projects-es/fly-fut-ligas/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fly-Fut Ligas"
 description: "Plataforma de fútbol de consumo con producción de vídeo asistida por IA y aplicación móvil."
-date: "Oct 01 2021"
+date: 2021-10-01
 type: "professional"
 translationKey: "fly-fut-ligas"
 hero: ../../../assets/projects/fly-fut-ligas/hero.png

--- a/src/content/projects-es/fly-fut-pro/index.md
+++ b/src/content/projects-es/fly-fut-pro/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fly-Fut Pro"
 description: "Sistema de análisis de fútbol profesional con controles de drones autónomos y análisis de vídeo táctico."
-date: "Jun 01 2022"
+date: 2022-06-01
 type: "professional"
 translationKey: "fly-fut-pro"
 hero: ../../../assets/projects/fly-fut-pro/hero.png

--- a/src/content/projects-es/fuera-de-juego/index.md
+++ b/src/content/projects-es/fuera-de-juego/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fuera de Juego"
 description: "Aplicación web mobile-first de página única que permite a los usuarios pronosticar partidos de fútbol y ganar premios promocionales."
-date: "Aug 01 2017"
+date: 2017-08-01
 type: "professional"
 translationKey: "fuera-de-juego"
 hero: ../../../assets/projects/fuera-de-juego/hero.jpg

--- a/src/content/projects-es/minerales-de-la-liga/index.md
+++ b/src/content/projects-es/minerales-de-la-liga/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Minerales de LaLiga"
 description: "Experiencia interactiva de arte de datos en 3D para Solán de Cabras × LaLiga: generación paramétrica de cristales, visualización en Three.js y pipeline de vídeo."
-date: "Jun 01 2024"
+date: 2024-06-01
 type: "professional"
 translationKey: "minerales-de-la-liga"
 ---

--- a/src/content/projects-es/movistar-bike-go/index.md
+++ b/src/content/projects-es/movistar-bike-go/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Movistar Bike & Go"
 description: "Aplicación móvil de ciclismo para Movistar que ofrece navegación de rutas y seguimiento de actividad para ciclistas."
-date: "Jan 01 2012"
+date: 2012-01-01
 type: "professional"
 translationKey: "movistar-bike-go"
 hero: ../../../assets/projects/movistar-bike-go/hero.jpg

--- a/src/content/projects-es/porcelanosa-ecommerce/index.md
+++ b/src/content/projects-es/porcelanosa-ecommerce/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Porcelanosa Ecommerce"
 description: "Migración de un Ecommerce global en Magento a una arquitectura headless en Adobe Commerce Cloud con Next.js y Payload CMS."
-date: "Jul 01 2025"
+date: 2025-07-01
 type: "professional"
 translationKey: "porcelanosa-ecommerce"
 demoURL: "https://store.porcelanosa.com/"

--- a/src/content/projects-es/quadrant-travel-cloud/index.md
+++ b/src/content/projects-es/quadrant-travel-cloud/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Quadrant Travel Cloud"
 description: "Plataforma de gestión de viajes corporativos que simplifica las reservas, la gestión de gastos y el cumplimiento de políticas."
-date: "Mar 01 2023"
+date: 2023-03-01
 type: "professional"
 translationKey: "quadrant-travel-cloud"
 ---

--- a/src/content/projects-es/sony-pictures-spain/index.md
+++ b/src/content/projects-es/sony-pictures-spain/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Sony Pictures Spain"
 description: "Web oficial en España de Sony Pictures Entertainment — migración de infraestructura de GCP a AWS, y mantenimiento y entrega continua de funcionalidades."
-date: "Jan 01 2023"
+date: 2023-01-01
 type: "professional"
 translationKey: "sony-pictures-spain"
 demoURL: "https://sonypictures.es/"

--- a/src/content/projects-es/telefonica-sdie-2017/index.md
+++ b/src/content/projects-es/telefonica-sdie-2017/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Telefónica SDiE 2017"
 description: "Aplicación web de página única con visualización interactiva de datos para el informe anual sobre la sociedad digital en España de Fundación Telefónica."
-date: "Jan 01 2017"
+date: 2017-01-01
 type: "professional"
 translationKey: "telefonica-sdie-2017"
 hero: ../../../assets/projects/telefonica-sdie-2017/hero.png

--- a/src/content/projects-es/un-mundo-aparte/index.md
+++ b/src/content/projects-es/un-mundo-aparte/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Un Mundo Aparte"
 description: "Aplicación móvil para Las Colinas Golf & Country Club que actúa como compañero digital para los huéspedes del resort."
-date: "Jan 01 2018"
+date: 2018-01-01
 type: "professional"
 translationKey: "un-mundo-aparte"
 hero: ../../../assets/projects/un-mundo-aparte/hero.jpg

--- a/src/content/projects-es/voltexa/index.md
+++ b/src/content/projects-es/voltexa/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Voltexa"
 description: "MVP para una startup de energía renovable — portal de clientes, panel de administración, branding, landing page y flujo de registro desarrollados con un equipo de cinco personas."
-date: "Jan 01 2023"
+date: 2023-01-01
 type: "professional"
 translationKey: "voltexa"
 hero: ../../../assets/projects/voltexa/hero.webp

--- a/src/content/work-en/bahiazul.md
+++ b/src/content/work-en/bahiazul.md
@@ -2,8 +2,8 @@
 company: "Bahiazul Resort"
 role: "Tech Lead & Creative Director"
 location: "Madrid, Spain"
-dateStart: "04/01/2020"
-dateEnd: "03/01/2021"
+dateStart: 2020-04-01
+dateEnd: 2021-03-01
 bullets:
   - "Redesigned resort website with Next.js, TypeScript, and Firebase, shipping SSR hosting with MDX-driven content"
   - "Built an internal Design System used across all web and mobile products, ensuring visual consistency"

--- a/src/content/work-en/fly-fut.md
+++ b/src/content/work-en/fly-fut.md
@@ -2,8 +2,8 @@
 company: "Fly-Fut"
 role: "Tech Lead"
 location: "Madrid, Spain"
-dateStart: "04/01/2021"
-dateEnd: "11/01/2022"
+dateStart: 2021-04-01
+dateEnd: 2022-11-01
 bullets:
   - "Led architecture and development of the consumer platform (Fly-Fut Ligas): backend, fully automated AI video pipeline for drone-recorded football matches, management tools, and mobile app"
   - "Designed and prototyped an iPad app for autonomous drone control in football training sessions"

--- a/src/content/work-en/interacso.md
+++ b/src/content/work-en/interacso.md
@@ -2,7 +2,7 @@
 company: "Interacso"
 role: "Tech Lead"
 location: "Madrid, Spain"
-dateStart: "11/01/2022"
+dateStart: 2022-11-01
 dateEnd: "Current"
 bullets:
   - "Lead software architecture, cloud infrastructure design, and technical decision-making for clients including Grupo Porcelanosa, Mediapro Brands, Mercado Ibérico del Gas (MIBGAS), and Sony Pictures Spain"

--- a/src/content/work-en/neolabels.md
+++ b/src/content/work-en/neolabels.md
@@ -2,8 +2,8 @@
 company: "Neo Labels"
 role: "Designer → R&D Consultant"
 location: "Madrid, Spain"
-dateStart: "05/01/2006"
-dateEnd: "06/01/2013"
+dateStart: 2006-05-01
+dateEnd: 2013-06-01
 bullets:
   - "Delivered end-to-end product work for 7 years: UX/UI design through full-stack development for digital campaigns and applications"
   - "Designed and built products for brands including Ferran Adrià (Adrià en casa), Telefónica Movistar, and Aramón"

--- a/src/content/work-en/piensa-diferente.md
+++ b/src/content/work-en/piensa-diferente.md
@@ -2,8 +2,8 @@
 company: "Piensa Diferente"
 role: "Head of Technology"
 location: "Madrid, Spain"
-dateStart: "07/01/2013"
-dateEnd: "03/01/2020"
+dateStart: 2013-07-01
+dateEnd: 2020-03-01
 bullets:
   - "Co-founded and led technology for a hospitality startup serving small resorts and B&Bs for 7 years"
   - "Designed and built a custom Property Management System (PMS) and client websites end-to-end"

--- a/src/content/work-en/sharemusic.md
+++ b/src/content/work-en/sharemusic.md
@@ -2,8 +2,8 @@
 company: "Sharemusic!"
 role: "Designer → Creative Director"
 location: "Madrid, Spain"
-dateStart: "05/01/2006"
-dateEnd: "12/01/2010"
+dateStart: 2006-05-01
+dateEnd: 2010-12-01
 bullets:
   - "Co-built atopechavalote.com, one of Spain's first social networks for nightlife, reaching 25,000 registered users"
   - "Evolved from designer to Creative Director: led branding, UX/UI design, and digital strategy"

--- a/src/content/work-es/bahiazul.md
+++ b/src/content/work-es/bahiazul.md
@@ -2,8 +2,8 @@
 company: "Bahiazul Resort"
 role: "Tech Lead & Creative Director"
 location: "Madrid, España"
-dateStart: "04/01/2020"
-dateEnd: "03/01/2021"
+dateStart: 2020-04-01
+dateEnd: 2021-03-01
 bullets:
   - "Rediseñé la web del resort con Next.js, TypeScript y Firebase, incluyendo SSR y contenido gestionado con MDX"
   - "Construí un Sistema de Diseño interno usado en todos los productos web y móviles para garantizar coherencia visual"

--- a/src/content/work-es/fly-fut.md
+++ b/src/content/work-es/fly-fut.md
@@ -2,8 +2,8 @@
 company: "Fly-Fut"
 role: "Tech Lead"
 location: "Madrid, España"
-dateStart: "04/01/2021"
-dateEnd: "11/01/2022"
+dateStart: 2021-04-01
+dateEnd: 2022-11-01
 bullets:
   - "Lideré la arquitectura y el desarrollo de la plataforma de consumo (Fly-Fut Ligas): backend, pipeline de vídeo automatizado con IA para partidos grabados con drones, herramientas de gestión y app móvil"
   - "Diseñé y prototipé una app iPad para el control autónomo de drones en entrenamientos de fútbol"

--- a/src/content/work-es/interacso.md
+++ b/src/content/work-es/interacso.md
@@ -2,7 +2,7 @@
 company: "Interacso"
 role: "Tech Lead"
 location: "Madrid, España"
-dateStart: "11/01/2022"
+dateStart: 2022-11-01
 dateEnd: "Actualidad"
 bullets:
   - "Lidero la arquitectura de software, diseño de infraestructura cloud y toma de decisiones técnicas para clientes como Grupo Porcelanosa, Mediapro Brands, Mercado Ibérico del Gas (MIBGAS) y Sony Pictures Spain"

--- a/src/content/work-es/neolabels.md
+++ b/src/content/work-es/neolabels.md
@@ -2,8 +2,8 @@
 company: "Neo Labels"
 role: "Diseñador → Consultor de I+D"
 location: "Madrid, España"
-dateStart: "05/01/2006"
-dateEnd: "06/01/2013"
+dateStart: 2006-05-01
+dateEnd: 2013-06-01
 bullets:
   - "Desarrollé productos de extremo a extremo durante 7 años: desde diseño UX/UI hasta desarrollo full-stack para campañas y aplicaciones digitales"
   - "Diseñé y construí productos para marcas como Ferran Adrià (Adrià en casa), Telefónica Movistar y Aramón"

--- a/src/content/work-es/piensa-diferente.md
+++ b/src/content/work-es/piensa-diferente.md
@@ -2,8 +2,8 @@
 company: "Piensa Diferente"
 role: "Head of Technology"
 location: "Madrid, España"
-dateStart: "07/01/2013"
-dateEnd: "03/01/2020"
+dateStart: 2013-07-01
+dateEnd: 2020-03-01
 bullets:
   - "Cofundé y lideré la tecnología de una startup hostelera durante 7 años, orientada a pequeños resorts y casas rurales"
   - "Diseñé y construí de extremo a extremo un Sistema de Gestión de Propiedades (PMS) y webs para clientes"

--- a/src/content/work-es/sharemusic.md
+++ b/src/content/work-es/sharemusic.md
@@ -2,8 +2,8 @@
 company: "Sharemusic!"
 role: "Diseñador → Director Creativo"
 location: "Madrid, España"
-dateStart: "05/01/2006"
-dateEnd: "12/01/2010"
+dateStart: 2006-05-01
+dateEnd: 2010-12-01
 bullets:
   - "Coconstruí atopechavalote.com, una de las primeras redes sociales de ocio nocturno en España, con 25.000 usuarios registrados"
   - "Evolucioné de diseñador a Director Creativo: lideré branding, diseño UX/UI y estrategia digital"


### PR DESCRIPTION
## Summary

- Migrates **projects** frontmatter from `"MMM DD YYYY"` locale strings → bare `YYYY-MM-DD`
- Migrates **work** frontmatter from `"MM/DD/YYYY"` → bare `YYYY-MM-DD`
- Removes the custom `parseWorkDate` parser from `src/content.config.ts` — replaced by `z.coerce.date()` for `dateStart` and a `z.union` of sentinel-string refine + `z.coerce.date()` for `dateEnd` (handles both `"Current"`/`"Actualidad"` and YAML-parsed date objects)
- Updates `generate-docx.mjs` `parseDate` to accept ISO strings alongside `Date` instances

All four content collections (`blog`, `projects`, `work`, `education`) now use the same canonical ISO 8601 date format.

## Test plan

- [ ] `astro sync` and `astro build` complete without errors (101 pages)
- [ ] Work experience dates render correctly on `/work` and `/en/work`
- [ ] Project dates render correctly on `/projects` and `/en/projects`
- [ ] CV PDF and DOCX export work experience date ranges are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)