### PR TITLE
feat(projects): show month and year only on project detail pages

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -1,19 +1,18 @@
 ---
 interface Props {
   date: Date;
+  format?: "full" | "month-year";
 }
 
-const { date } = Astro.props;
+const { date, format = "full" } = Astro.props;
 const locale = Astro.currentLocale ?? "es";
+
+const options: Intl.DateTimeFormatOptions =
+  format === "month-year"
+    ? { month: "long", year: "numeric", timeZone: "UTC" }
+    : { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" };
 ---
 
 <time datetime={date.toISOString()}>
-  {
-    date.toLocaleDateString(locale, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      timeZone: "UTC",
-    })
-  }
+  {date.toLocaleDateString(locale, options)}
 </time>

--- a/src/pages/en/projects/[...slug].astro
+++ b/src/pages/en/projects/[...slug].astro
@@ -41,7 +41,7 @@ const { Content } = await render(project);
     <div class="space-y-1 my-10">
       <div class="animate flex items-center gap-1.5">
         <div class="font-base text-sm">
-          <FormattedDate date={project.data.date} />
+          <FormattedDate date={project.data.date} format="month-year" />
         </div>
       </div>
       <div class="animate text-2xl font-semibold text-black dark:text-white">

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -41,7 +41,7 @@ const { Content } = await render(project);
     <div class="space-y-1 my-10">
       <div class="animate flex items-center gap-1.5">
         <div class="font-base text-sm">
-          <FormattedDate date={project.data.date} />
+          <FormattedDate date={project.data.date} format="month-year" />
         </div>
       </div>
       <div class="animate text-2xl font-semibold text-black dark:text-white">


### PR DESCRIPTION
## Summary

- Adds a `format` prop (`"full"` | `"month-year"`) to `FormattedDate.astro`
- Both ES and EN project detail pages now render dates as e.g. "junio 2025" / "June 2025"
- Blog and work pages are unaffected (default remains `"full"`)

## Test plan

- [ ] Visit a project detail page in ES — date shows month + year only
- [ ] Visit the same project in EN — date localises correctly to English
- [ ] Visit a blog post — date still shows full format (day + month + year)
- [ ] `pnpm lint && pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)