### PR TITLE
fix(projects): re-run filter script after View Transitions + un-mundo-aparte UX copy fix

### DIFF
--- a/src/content/projects-en/un-mundo-aparte/index.md
+++ b/src/content/projects-en/un-mundo-aparte/index.md
@@ -18,7 +18,7 @@ The app served as a digital companion for guests, providing access to resort ser
 As **Tech Lead** and **UX Lead**, I was responsible for:
 
 - Overall system architecture and technical direction of the project.
-- UX design of the mobile application.
+- UX design of the management backoffice.
 - Leading the development team.
 
 ## Technologies

--- a/src/content/projects-es/un-mundo-aparte/index.md
+++ b/src/content/projects-es/un-mundo-aparte/index.md
@@ -18,7 +18,7 @@ La aplicación servía como compañero digital para los huéspedes, proporcionan
 Como **Líder Técnico** y **Líder de UX**, fui responsable de:
 
 - La arquitectura del sistema y la dirección técnica general del proyecto.
-- El diseño UX de la aplicación móvil.
+- El diseño UX del backoffice de gestión.
 - La dirección del equipo de desarrollo.
 
 ## Tecnologías

--- a/src/pages/en/projects/index.astro
+++ b/src/pages/en/projects/index.astro
@@ -70,7 +70,7 @@ const activeFilter: Filter = VALID_FILTERS.includes(rawParam as typeof VALID_FIL
   }
 </style>
 
-<script is:inline>
+<script is:inline data-astro-rerun>
   (function () {
     const VALID = ["professional", "personal"];
 

--- a/src/pages/en/projects/index.astro
+++ b/src/pages/en/projects/index.astro
@@ -127,11 +127,15 @@ const activeFilter: Filter = VALID_FILTERS.includes(rawParam as typeof VALID_FIL
       });
     }
 
-    if (!window._projectsFilterListenerAttached) {
-      window._projectsFilterListenerAttached = true;
-      window.addEventListener("popstate", function () {
-        applyFilter(getFilter());
-      });
+    function handlePopState() {
+      applyFilter(getFilter());
     }
+
+    window.addEventListener("popstate", handlePopState);
+
+    document.addEventListener("astro:before-swap", function cleanup() {
+      window.removeEventListener("popstate", handlePopState);
+      document.removeEventListener("astro:before-swap", cleanup);
+    }, { once: true });
   })();
 </script>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -70,7 +70,7 @@ const activeFilter: Filter = VALID_FILTERS.includes(rawParam as typeof VALID_FIL
   }
 </style>
 
-<script is:inline>
+<script is:inline data-astro-rerun>
   (function () {
     const VALID = ["professional", "personal"];
 

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -127,11 +127,15 @@ const activeFilter: Filter = VALID_FILTERS.includes(rawParam as typeof VALID_FIL
       });
     }
 
-    if (!window._projectsFilterListenerAttached) {
-      window._projectsFilterListenerAttached = true;
-      window.addEventListener("popstate", function () {
-        applyFilter(getFilter());
-      });
+    function handlePopState() {
+      applyFilter(getFilter());
     }
+
+    window.addEventListener("popstate", handlePopState);
+
+    document.addEventListener("astro:before-swap", function cleanup() {
+      window.removeEventListener("popstate", handlePopState);
+      document.removeEventListener("astro:before-swap", cleanup);
+    }, { once: true });
   })();
 </script>


### PR DESCRIPTION
## Summary

- **Bug fix:** Project filters stopped working after switching language via the language switcher. Root cause: Astro's `ClientRouter` deduplicates identical `<script is:inline>` blocks across pages and skips re-execution — so click listeners were never re-attached to the new DOM buttons after a client-side navigation. Fixed by adding `data-astro-rerun` to both ES and EN project index pages.
- **Content fix:** Corrected UX scope in the Un Mundo Aparte project entry (backoffice, not mobile app).

## Test plan

- [ ] Navigate to `/projects`, switch language to EN — filter buttons should still work
- [ ] Apply a filter (e.g. Professional), switch language — filter buttons should work on the EN page
- [ ] Navigate back to ES — filters still functional
- [ ] Un Mundo Aparte project page shows "UX design of the management backoffice" in EN and the Spanish equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)